### PR TITLE
FEAT - ADD DOCS CAREERS

### DIFF
--- a/docs/2023/IngCivil.ts
+++ b/docs/2023/IngCivil.ts
@@ -1,0 +1,284 @@
+import { RegimenCorrelatividades } from "../interfaces/regimen";
+
+export const plan_ing_civil_2023: RegimenCorrelatividades = {
+    "carrera": "Ingeniería Civil",
+    "plan": "2023",
+      "regimen_correlatividades": [
+        {
+          "nivel": "I",
+          "asignaturas": [
+            {
+              "numero": 1,
+              "nombre": "ANÁLISIS MATEMÁTICO I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 2,
+              "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 3,
+              "nombre": "INGENIERÍA Y SOCIEDAD",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 4,
+              "nombre": "INGENIERÍA CIVIL I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 5,
+              "nombre": "SISTEMAS DE REPRESENTACIÓN",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 6,
+              "nombre": "FÍSICA I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 7,
+              "nombre": "QUÍMICA GENERAL",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 8,
+              "nombre": "INGLÉS I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 9,
+              "nombre": "FUNDAMENTOS DE INFORMÁTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            }
+          ]
+        },
+        {
+          "nivel": "II",
+          "asignaturas": [
+            {
+              "numero": 10,
+              "nombre": "ANÁLISIS MATEMÁTICO II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2]
+            },
+            {
+              "numero": 11,
+              "nombre": "ESTABILIDAD",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2, 5, 6, 9]
+            },
+            {
+              "numero": 12,
+              "nombre": "INGENIERÍA CIVIL II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [3, 4, 5, 9]
+            },
+            {
+              "numero": 13,
+              "nombre": "TECNOLOGÍA DE LOS MATERIALES",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 5, 7, 6]
+            },
+            {
+              "numero": 14,
+              "nombre": "FÍSICA II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 6]
+            },
+            {
+              "numero": 15,
+              "nombre": "PROBABILIDAD Y ESTADÍSTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2]
+            }
+          ]
+        },
+        {
+          "nivel": "III",
+          "asignaturas": [
+            {
+              "numero": 16,
+              "nombre": "RESISTENCIA DE LOS MATERIALES",
+              "para_cursar_aprobar": [1, 2, 6, 9],
+              "para_cursar_cursar": [11]
+            },
+            {
+              "numero": 17,
+              "nombre": "TECNOLOGÍA DEL HORMIGÓN",
+              "para_cursar_aprobar": [1, 2, 7, 6],
+              "para_cursar_cursar": [13, 15, 8]
+            },
+            {
+              "numero": 18,
+              "nombre": "TECNOLOGÍA DE LA CONSTRUCCIÓN",
+              "para_cursar_aprobar": [1, 2, 4, 5, 7, 6, 9],
+              "para_cursar_cursar": [11, 12, 13, 8]
+            },
+            {
+              "numero": 19,
+              "nombre": "INSTALACIONES TERMOMECÁNICAS",
+              "para_cursar_aprobar": [1, 2, 4, 5, 7, 6],
+              "para_cursar_cursar": [12, 13, 14]
+            },
+            {
+              "numero": 20,
+              "nombre": "GEOTOPOGRAFÍA",
+              "para_cursar_aprobar": [1, 2, 4, 5, 6],
+              "para_cursar_cursar": [10, 12, 14, 15]
+            },
+            {
+              "numero": 21,
+              "nombre": "HIDRÁULICA GENERAL Y APLICADA",
+              "para_cursar_aprobar": [1, 2, 5, 6, 9],
+              "para_cursar_cursar": [10, 11, 12, 14, 15]
+            },
+            {
+              "numero": 22,
+              "nombre": "CÁLCULO AVANZADO",
+              "para_cursar_aprobar": [1, 2, 5, 6, 9],
+              "para_cursar_cursar": [10, 11, 13, 15]
+            },
+            {
+              "numero": 23,
+              "nombre": "INSTALACIONES ELÉCTRICAS Y ACÚSTICAS",
+              "para_cursar_aprobar": [1, 2, 4, 5, 7, 6],
+              "para_cursar_cursar": [12, 13, 14]
+            },
+            {
+              "numero": 24,
+              "nombre": "ECONOMÍA",
+              "para_cursar_aprobar": [1, 2, 3, 4, 9],
+              "para_cursar_cursar": [12, 15, 8]
+            },
+            {
+              "numero": 25,
+              "nombre": "INGLÉS TÉCNICO II",
+              "para_cursar_aprobar": [3, 4],
+              "para_cursar_cursar": [8]
+            }
+          ]
+        },
+        {
+          "nivel": "IV",
+          "asignaturas": [
+            {
+              "numero": 26,
+              "nombre": "GEOTECNIA",
+              "para_cursar_aprobar": [10, 11, 12, 13, 14, 15],
+              "para_cursar_cursar": [16, 17, 18, 20, 21]
+            },
+            {
+              "numero": 27,
+              "nombre": "INSTALACIONES SANITARIAS Y DE GAS",
+              "para_cursar_aprobar": [5, 7, 6, 9, 13],
+              "para_cursar_cursar": [18, 20, 21, 24]
+            },
+            {
+              "numero": 28,
+              "nombre": "ANÁLISIS ESTRUCTURAL I",
+              "para_cursar_aprobar": [10, 12, 11, 15],
+              "para_cursar_cursar": [16, 17]
+            },
+            {
+              "numero": 29,
+              "nombre": "DISEÑO ARQ. PLANEAMIENTO Y URBANISMO I",
+              "para_cursar_aprobar": [11, 12, 13, 8],
+              "para_cursar_cursar": [18, 20, 23, 19, 24, 25]
+            },
+            {
+              "numero": 30,
+              "nombre": "ESTRUCTURAS DE HORMIGÓN",
+              "para_cursar_aprobar": [10, 11, 12, 13, 14, 15],
+              "para_cursar_cursar": [16, 17, 18, 20, 25]
+            },
+            {
+              "numero": 31,
+              "nombre": "HIDROLOGÍA Y OBRAS HIDRÁULICAS",
+              "para_cursar_aprobar": [10, 11, 12, 13, 14, 15],
+              "para_cursar_cursar": [16, 18, 20, 21, 24, 25]
+            },
+            {
+              "numero": 32,
+              "nombre": "INGENIERÍA LEGAL",
+              "para_cursar_aprobar": [1, 2, 3, 4, 9],
+              "para_cursar_cursar": [10, 12, 15]
+            }
+          ]
+        },
+        {
+          "nivel": "V",
+          "asignaturas": [
+            {
+              "numero": 33,
+              "nombre": "CONSTRUCCIONES METÁLICAS Y DE MADERA",
+              "para_cursar_aprobar": [16, 17, 18, 20],
+              "para_cursar_cursar": [22, 28]
+            },
+            {
+              "numero": 34,
+              "nombre": "CIMENTACIONES",
+              "para_cursar_aprobar": [16, 17, 18, 20, 21],
+              "para_cursar_cursar": [22, 26, 28, 30, 31]
+            },
+            {
+              "numero": 35,
+              "nombre": "ORGANIZACIÓN Y CONDUCCIÓN DE OBRAS",
+              "para_cursar_aprobar": [17, 18, 20, 21, 23, 19, 24, 25],
+              "para_cursar_cursar": [26, 27, 29, 30, 31]
+            },
+            {
+              "numero": 36,
+              "nombre": "VIAS DE COMUNICACIÓN I",
+              "para_cursar_aprobar": [10, 11, 12, 13, 15, 8],
+              "para_cursar_cursar": [17, 18, 20]
+            },
+            {
+              "numero": 37,
+              "nombre": "ANÁLISIS ESTRUCTURAL II",
+              "para_cursar_aprobar": [16, 17, 18, 20, 25],
+              "para_cursar_cursar": [22, 26, 28, 30, 31]
+            },
+            {
+              "numero": 38,
+              "nombre": "INGENIERÍA SANITARIA",
+              "para_cursar_aprobar": [17, 18, 20, 21, 25],
+              "para_cursar_cursar": [26, 27, 31]
+            },
+            {
+              "numero": 39,
+              "nombre": "VIAS DE COMUNICACIÓN II",
+              "para_cursar_aprobar": [16, 17, 18, 20, 21, 24],
+              "para_cursar_cursar": [26, 30, 31, 32, 36]
+            },
+            {
+              "numero": 40,
+              "nombre": "GESTIÓN AMBIENTAL Y DESARROLLO SUSTENTABLE",
+              "para_cursar_aprobar": [21, 24, 25],
+              "para_cursar_cursar": [26, 29, 31, 32]
+            },
+            {
+              "numero": 41,
+              "nombre": "PROYECTO FINAL",
+              "para_cursar_aprobar": [8, 16, 17, 18, 20, 21, 24, 23, 19, 25],
+              "para_cursar_cursar": [26, 27, 32, 29, 28, 30, 31]
+            }
+          ]
+        }
+      ],
+      "condiciones_adicionales": {
+        "proyecto_final": "Ninguna condición adicional explícita para Proyecto Final más allá de las correlatividades de la asignatura.",
+        "practica_profesional_supervisada": "Ninguna condición adicional explícita para Práctica Profesional Supervisada."
+      }
+    }
+  

--- a/docs/2023/IngElectrica.ts
+++ b/docs/2023/IngElectrica.ts
@@ -1,0 +1,289 @@
+import { RegimenCorrelatividades } from "../interfaces/regimen";
+
+export const plan_ing_electrica_2025: RegimenCorrelatividades = {
+    "carrera": "Ingeniería Eléctrica",
+    "plan": "2025a",
+    "regimen_correlatividades": [
+      {
+        "nivel": "I",
+        "asignaturas": [
+          {
+            "numero": 1,
+            "nombre": "ANÁLISIS MATEMÁTICO I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 2,
+            "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 3,
+            "nombre": "INGENIERÍA Y SOCIEDAD",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 4,
+            "nombre": "INTEGRACIÓN ELÉCTRICA I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 5,
+            "nombre": "SISTEMAS DE REPRESENTACIÓN",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 6,
+            "nombre": "FÍSICA I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 7,
+            "nombre": "QUÍMICA GENERAL",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 8,
+            "nombre": "FÍSICA",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 9,
+            "nombre": "FUNDAMENTOS DE INFORMÁTICA",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 10,
+            "nombre": "INGLÉS I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          }
+        ]
+      },
+      {
+        "nivel": "II",
+        "asignaturas": [
+          {
+            "numero": 11,
+            "nombre": "ANÁLISIS MATEMÁTICO II",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 2]
+          },
+          {
+            "numero": 12,
+            "nombre": "ESTABILIDAD",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 2, 6]
+          },
+          {
+            "numero": 13,
+            "nombre": "INTEGRACIÓN ELÉCTRICA II",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 6, 4]
+          },
+          {
+            "numero": 14,
+            "nombre": "ELECTROTECNIA I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 2, 6]
+          },
+          {
+            "numero": 15,
+            "nombre": "FÍSICA II",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 6]
+          },
+          {
+            "numero": 16,
+            "nombre": "MECÁNICA TÉCNICA",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 6]
+          },
+          {
+            "numero": 17,
+            "nombre": "CÁLCULO NUMÉRICO",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 2, 6, 9]
+          },
+          {
+            "numero": 18,
+            "nombre": "PROBABILIDAD Y ESTADÍSTICA",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 2]
+          },
+          {
+            "numero": 19,
+            "nombre": "TALLER INTERDISCIPLINARIO",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 20,
+            "nombre": "FUNDAMENTOS PARA EL ANÁLISIS DE SEÑALES",
+            "para_cursar_aprobar": [1, 2],
+            "para_cursar_cursar": [11, 17]
+          }
+        ]
+      },
+      {
+        "nivel": "III",
+        "asignaturas": [
+          {
+            "numero": 21,
+            "nombre": "TECNOLOGÍAS Y ENSAYOS DE MATERIALES ELÉCTRICOS",
+            "para_cursar_aprobar": [1, 6],
+            "para_cursar_cursar": [7, 15]
+          },
+          {
+            "numero": 22,
+            "nombre": "INSTRUMENTOS Y MEDICIONES ELÉCTRICAS",
+            "para_cursar_aprobar": [1, 2, 6],
+            "para_cursar_cursar": [18, 14]
+          },
+          {
+            "numero": 23,
+            "nombre": "TEORÍA DE LOS CAMPOS",
+            "para_cursar_aprobar": [1, 2, 6],
+            "para_cursar_cursar": [15, 11]
+          },
+          {
+            "numero": 24,
+            "nombre": "FÍSICA III",
+            "para_cursar_aprobar": [1, 2, 6],
+            "para_cursar_cursar": [15, 11]
+          },
+          {
+            "numero": 25,
+            "nombre": "MÁQUINAS ELÉCTRICAS I",
+            "para_cursar_aprobar": [1, 6],
+            "para_cursar_cursar": [15, 14, 11, 17]
+          },
+          {
+            "numero": 26,
+            "nombre": "ELECTROTECNIA II",
+            "para_cursar_aprobar": [1, 2, 6],
+            "para_cursar_cursar": [15, 14, 11]
+          },
+          {
+            "numero": 27,
+            "nombre": "TERMODINÁMICA",
+            "para_cursar_aprobar": [1, 2, 6],
+            "para_cursar_cursar": [15, 11]
+          },
+          {
+            "numero": 28,
+            "nombre": "SEGURIDAD, RIESGO ELÉCTRICO Y MEDIO AMBIENTE",
+            "para_cursar_aprobar": [1, 2, 6, 15, 11],
+            "para_cursar_cursar": [7, 14, 21, 23]
+          },
+          {
+            "numero": 29,
+            "nombre": "INSTALACIONES ELÉCTRICAS Y LUMINOTECNIA",
+            "para_cursar_aprobar": [7, 6, 14, 13, 10, 11],
+            "para_cursar_cursar": [21, 25, 26]
+          },
+          {
+            "numero": 30,
+            "nombre": "INGLÉS II",
+            "para_cursar_aprobar": [10],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 31,
+            "nombre": "ECONOMÍA",
+            "para_cursar_aprobar": [3],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 32,
+            "nombre": "LEGISLACIÓN",
+            "para_cursar_aprobar": [3],
+            "para_cursar_cursar": []
+          }
+        ]
+      },
+      {
+        "nivel": "IV",
+        "asignaturas": [
+          {
+            "numero": 33,
+            "nombre": "ELECTRÓNICA I",
+            "para_cursar_aprobar": [1, 6],
+            "para_cursar_cursar": [14]
+          },
+          {
+            "numero": 34,
+            "nombre": "MÁQUINAS ELÉCTRICAS II",
+            "para_cursar_aprobar": [7, 15, 18, 14, 10, 11],
+            "para_cursar_cursar": [21, 22, 23, 25, 26]
+          },
+          {
+            "numero": 35,
+            "nombre": "CONTROL AUTOMÁTICO",
+            "para_cursar_aprobar": [14, 11],
+            "para_cursar_cursar": [26, 20]
+          },
+          {
+            "numero": 36,
+            "nombre": "MÁQUINAS TÉRMICAS, HIDRÁULICAS Y DE FLUIDO",
+            "para_cursar_aprobar": [15, 11],
+            "para_cursar_cursar": [12, 16, 27]
+          }
+        ]
+      },
+      {
+        "nivel": "V",
+        "asignaturas": [
+          {
+            "numero": 37,
+            "nombre": "GENERACIÓN, TRANSMISIÓN Y DISTRIBUCIÓN DE LA ENERGÍA ELÉCTRICA",
+            "para_cursar_aprobar": [12, 16, 21, 25, 26, 27],
+            "para_cursar_cursar": [24, 34, 36]
+          },
+          {
+            "numero": 38,
+            "nombre": "ELECTRÓNICA II",
+            "para_cursar_aprobar": [14, 19],
+            "para_cursar_cursar": [26, 33]
+          },
+          {
+            "numero": 39,
+            "nombre": "SISTEMAS DE POTENCIA",
+            "para_cursar_aprobar": [21, 25, 26, 19],
+            "para_cursar_cursar": [34, 35]
+          },
+          {
+            "numero": 40,
+            "nombre": "ACCIONAMIENTOS Y CONTROLES ELÉCTRICOS",
+            "para_cursar_aprobar": [14, 21, 25, 26, 20, 19],
+            "para_cursar_cursar": [33, 34, 35]
+          },
+          {
+            "numero": 41,
+            "nombre": "ORGANIZACIÓN Y ADMINISTRACIÓN DE EMPRESAS",
+            "para_cursar_aprobar": [19],
+            "para_cursar_cursar": [31, 32]
+          },
+          {
+            "numero": 42,
+            "nombre": "PROYECTO FINAL",
+            "para_cursar_aprobar": [21, 22, 25, 26, 20, 19, 30],
+            "para_cursar_cursar": [31, 34, 29, 35]
+          }
+        ]
+      }
+    ],
+    "condiciones_adicionales": {
+      "proyecto_final": "Es condición para iniciar y acreditar el Taller, el cumplimiento de los requisitos académicos exigidos para la inscripción a Máquinas Eléctricas I.  Ninguna condición adicional explícita para Proyecto Final más allá de las correlatividades de la asignatura. ",
+      "practica_profesional_supervisada": "No se especifica información adicional para la Práctica Profesional Supervisada en el documento."
+    }
+  }

--- a/docs/2023/IngElectronica.ts
+++ b/docs/2023/IngElectronica.ts
@@ -1,0 +1,259 @@
+import { RegimenCorrelatividades } from "../interfaces/regimen";
+
+export const plan_ing_electronica_2023: RegimenCorrelatividades = {
+      "carrera": "Ingeniería Electrónica",
+      "plan": "2025a",
+      "regimen_correlatividades": [
+        {
+          "nivel": "I",
+          "asignaturas": [
+            {
+              "numero": 1,
+              "nombre": "ANÁLISIS MATEMÁTICO I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 2,
+              "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 3,
+              "nombre": "INGENIERÍA Y SOCIEDAD",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 4,
+              "nombre": "INFORMÁTICA I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 5,
+              "nombre": "FÍSICA I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 6,
+              "nombre": "INGLÉS I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [3]
+            },
+            {
+              "numero": 7,
+              "nombre": "DISEÑO ASISTIDO POR COMPUTADORA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            }
+          ]
+        },
+        {
+          "nivel": "II",
+          "asignaturas": [
+            {
+              "numero": 8,
+              "nombre": "QUÍMICA GENERAL",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 9,
+              "nombre": "INFORMÁTICA II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [4, 1, 2]
+            },
+            {
+              "numero": 10,
+              "nombre": "ANÁLISIS DE SEÑALES Y SISTEMAS",
+              "para_cursar_aprobar": [1, 2],
+              "para_cursar_cursar": [11]
+            },
+            {
+              "numero": 11,
+              "nombre": "FÍSICA II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 5]
+            },
+            {
+              "numero": 12,
+              "nombre": "LEGISLACIÓN",
+              "para_cursar_aprobar": [3],
+              "para_cursar_cursar": [9]
+            },
+            {
+              "numero": 13,
+              "nombre": "PROBABILIDAD Y ESTADÍSTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2]
+            },
+            {
+              "numero": 14,
+              "nombre": "ANÁLISIS MATEMÁTICO II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2]
+            },
+            {
+              "numero": 15,
+              "nombre": "FÍSICA ELECTRÓNICA",
+              "para_cursar_aprobar": [1, 2, 5],
+              "para_cursar_cursar": [11]
+            },
+            {
+              "numero": 16,
+              "nombre": "SEGURIDAD, HIGIENE Y MEDIO AMBIENTE",
+              "para_cursar_aprobar": [3, 8],
+              "para_cursar_cursar": []
+            }
+          ]
+        },
+        {
+          "nivel": "III",
+          "asignaturas": [
+            {
+              "numero": 17,
+              "nombre": "TEORÍA DE LOS CIRCUITOS I",
+              "para_cursar_aprobar": [1, 5],
+              "para_cursar_cursar": [14, 11]
+            },
+            {
+              "numero": 18,
+              "nombre": "TÉCNICAS DIGITALES I",
+              "para_cursar_aprobar": [2],
+              "para_cursar_cursar": [4]
+            },
+            {
+              "numero": 19,
+              "nombre": "DISPOSITIVOS ELECTRÓNICOS",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [4, 1, 8]
+            },
+            {
+              "numero": 20,
+              "nombre": "ELECTRÓNICA APLICADA I",
+              "para_cursar_aprobar": [4, 1, 5],
+              "para_cursar_cursar": [8, 11]
+            },
+            {
+              "numero": 21,
+              "nombre": "INGLÉS II",
+              "para_cursar_aprobar": [6],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 22,
+              "nombre": "MEDIOS DE ENLACE",
+              "para_cursar_aprobar": [1, 2, 5],
+              "para_cursar_cursar": [14, 11]
+            },
+            {
+              "numero": 23,
+              "nombre": "ECONOMÍA",
+              "para_cursar_aprobar": [3],
+              "para_cursar_cursar": [9]
+            }
+          ]
+        },
+        {
+          "nivel": "IV",
+          "asignaturas": [
+            {
+              "numero": 24,
+              "nombre": "TÉCNICAS DIGITALES II",
+              "para_cursar_aprobar": [8, 11],
+              "para_cursar_cursar": [9, 18, 20]
+            },
+            {
+              "numero": 25,
+              "nombre": "MEDIDAS ELECTRÓNICAS I",
+              "para_cursar_aprobar": [14, 8, 11],
+              "para_cursar_cursar": [10, 17, 18, 20]
+            },
+            {
+              "numero": 26,
+              "nombre": "TEORÍA DE LOS CIRCUITOS II",
+              "para_cursar_aprobar": [14, 11],
+              "para_cursar_cursar": [10, 17]
+            },
+            {
+              "numero": 27,
+              "nombre": "MÁQUINAS E INSTALACIONES ELÉCTRICAS",
+              "para_cursar_aprobar": [14, 11],
+              "para_cursar_cursar": [10, 17]
+            },
+            {
+              "numero": 28,
+              "nombre": "SISTEMAS DE COMUNICACIONES",
+              "para_cursar_aprobar": [14, 11],
+              "para_cursar_cursar": [10, 13, 20, 22]
+            },
+            {
+              "numero": 29,
+              "nombre": "ELECTRÓNICA APLICADA II",
+              "para_cursar_aprobar": [14, 11, 21],
+              "para_cursar_cursar": [10, 15, 17, 19, 20]
+            }
+          ]
+        },
+        {
+          "nivel": "V",
+          "asignaturas": [
+            {
+              "numero": 30,
+              "nombre": "TÉCNICAS DIGITALES III",
+              "para_cursar_aprobar": [9, 18, 20],
+              "para_cursar_cursar": [24]
+            },
+            {
+              "numero": 31,
+              "nombre": "MEDIDAS ELECTRÓNICAS II",
+              "para_cursar_aprobar": [7, 15, 17, 18, 20, 21],
+              "para_cursar_cursar": [24, 25, 28, 29]
+            },
+            {
+              "numero": 32,
+              "nombre": "SISTEMAS DE CONTROL",
+              "para_cursar_aprobar": [15, 17],
+              "para_cursar_cursar": [26, 27]
+            },
+            {
+              "numero": 33,
+              "nombre": "ELECTRÓNICA APLICADA III",
+              "para_cursar_aprobar": [15, 17, 20],
+              "para_cursar_cursar": [26, 28, 29]
+            },
+            {
+              "numero": 34,
+              "nombre": "TECNOLOGÍA ELECTRÓNICA",
+              "para_cursar_aprobar": [15, 18, 20],
+              "para_cursar_cursar": [25]
+            },
+            {
+              "numero": 35,
+              "nombre": "ELECTRÓNICA DE POTENCIA",
+              "para_cursar_aprobar": [15, 18, 20],
+              "para_cursar_cursar": [25, 27, 29]
+            },
+            {
+              "numero": 36,
+              "nombre": "ORGANIZACIÓN INDUSTRIAL",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [12]
+            },
+            {
+              "numero": 37,
+              "nombre": "PROYECTO FINAL",
+              "para_cursar_aprobar": [24, 25, 29],
+              "para_cursar_cursar": [30, 31, 33],
+            }
+          ]
+        }
+      ],
+      "condiciones_adicionales": {
+        "proyecto_final": "Para cursar Proyecto Final: Técnicas Digitales III, Medidas Electrónicas II, Electrónica Aplicada III. Para rendir Proyecto Final: TODAS las asignaturas previas aprobadas. ",
+        "practica_profesional_supervisada": "No se especifica información adicional para la Práctica Profesional Supervisada en el documento."
+      }
+    }

--- a/docs/2023/IngEnSistemas.ts
+++ b/docs/2023/IngEnSistemas.ts
@@ -1,0 +1,253 @@
+import { RegimenCorrelatividades } from "../interfaces/regimen";
+
+export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
+    "carrera": "Ingeniería en Sistemas de Información",
+    "plan": "2023",
+    "regimen_correlatividades": [
+      {
+        "nivel": 1,
+        "asignaturas": [
+          {
+            "numero": 1,
+            "nombre": "Análisis Matemático I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 2,
+            "nombre": "Álgebra y Geometría Analítica",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 3,
+            "nombre": "Física I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 4,
+            "nombre": "Inglés I",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 5,
+            "nombre": "Lógica y Estructuras Discretas",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 6,
+            "nombre": "Algoritmos y Estructuras de Datos",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 7,
+            "nombre": "Arquitectura de Computadoras",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 8,
+            "nombre": "Sistemas y Procesos de Negocio",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 9,
+            "nombre": "Análisis Matemático II",
+            "para_cursar_aprobar": [1, 2],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 10,
+            "nombre": "Física II",
+            "para_cursar_aprobar": [1, 3],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 11,
+            "nombre": "Ingeniería y Sociedad",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 12,
+            "nombre": "Inglés II",
+            "para_cursar_aprobar": [4],
+            "para_cursar_cursar": []
+          }
+        ]
+      },
+      {
+        "nivel": "II",
+        "asignaturas": [
+          {
+            "numero": 13,
+            "nombre": "Sintaxis y Semántica de los Lenguajes",
+            "para_cursar_aprobar": [5, 6],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 14,
+            "nombre": "Paradigmas de Programación",
+            "para_cursar_aprobar": [5, 6],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 15,
+            "nombre": "Sistemas Operativos",
+            "para_cursar_aprobar": [7],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 16,
+            "nombre": "Análisis de Sistemas de Información (integradora)",
+            "para_cursar_aprobar": [6, 8],
+            "para_cursar_cursar": []
+          }
+        ]
+      },
+      {
+        "nivel": "III",
+        "asignaturas": [
+          {
+            "numero": 17,
+            "nombre": "Probabilidad y Estadística",
+            "para_cursar_aprobar": [1, 2],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 18,
+            "nombre": "Economía",
+            "para_cursar_aprobar": [1, 2],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 19,
+            "nombre": "Bases de Datos",
+            "para_cursar_aprobar": [13, 16],
+            "para_cursar_cursar": [5, 6]
+          },
+          {
+            "numero": 20,
+            "nombre": "Desarrollo de Software",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [5, 6, 14, 16]
+          },
+          {
+            "numero": 21,
+            "nombre": "Comunicación de Datos",
+            "para_cursar_aprobar": [3, 7],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 22,
+            "nombre": "Análisis Numérico",
+            "para_cursar_aprobar": [9],
+            "para_cursar_cursar": [1, 2]
+          },
+          {
+            "numero": 23,
+            "nombre": "Diseño de Sistemas de Información (integradora)",
+            "para_cursar_aprobar": [14, 16],
+            "para_cursar_cursar": [4, 6, 8]
+          },
+          {
+            "numero": 24,
+            "nombre": "Legislación",
+            "para_cursar_aprobar": [11],
+            "para_cursar_cursar": []
+          }
+        ]
+      },
+      {
+        "nivel": "IV",
+        "asignaturas": [
+          {
+            "numero": 25,
+            "nombre": "Ingeniería y Calidad de Software",
+            "para_cursar_aprobar": [19, 20, 23],
+            "para_cursar_cursar": [13, 14]
+          },
+          {
+            "numero": 26,
+            "nombre": "Redes de Datos",
+            "para_cursar_aprobar": [15, 21],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 27,
+            "nombre": "Investigación Operativa",
+            "para_cursar_aprobar": [17, 22],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 28,
+            "nombre": "Simulación",
+            "para_cursar_aprobar": [17],
+            "para_cursar_cursar": [9]
+          },
+          {
+            "numero": 29,
+            "nombre": "Tecnologías para la automatización",
+            "para_cursar_aprobar": [10, 22],
+            "para_cursar_cursar": [9]
+          },
+          {
+            "numero": 30,
+            "nombre": "Administración de Sistemas de Información (integradora)",
+            "para_cursar_aprobar": [16],
+            "para_cursar_cursar": [18, 23]
+          }
+        ]
+      },
+      {
+        "nivel": "V",
+        "asignaturas": [
+          {
+            "numero": 31,
+            "nombre": "Inteligencia Artificial",
+            "para_cursar_aprobar": [17, 22],
+            "para_cursar_cursar": [28]
+          },
+          {
+            "numero": 32,
+            "nombre": "Ciencia de Datos",
+            "para_cursar_aprobar": [17, 19],
+            "para_cursar_cursar": [28]
+          },
+          {
+            "numero": 33,
+            "nombre": "Sistemas de Gestión",
+            "para_cursar_aprobar": [18, 27],
+            "para_cursar_cursar": [23]
+          },
+          {
+            "numero": 34,
+            "nombre": "Gestión Gerencial",
+            "para_cursar_aprobar": [24, 30],
+            "para_cursar_cursar": [18]
+          },
+          {
+            "numero": 35,
+            "nombre": "Seguridad en los Sistemas de Información",
+            "para_cursar_aprobar": [20, 21],
+            "para_cursar_cursar": [26, 30]
+          },
+          {
+            "numero": 36,
+            "nombre": "Proyecto Final (integradora)",
+            "para_cursar_aprobar": [25, 26, 30],
+            "para_cursar_cursar": [12, 20, 23]
+          }
+        ]
+      }
+    ],
+    "condiciones_adicionales": {
+      "proyecto_final": "Es condición para rendir Proyecto Final, aprobar todas las asignaturas previas del Plan de Estudios.",
+      "practica_profesional_supervisada": "Es condición previa para iniciar y acreditar la Práctica Profesional Supervisada el cumplimiento de los requisitos académicos exigidos para la inscripción a Proyecto Final."
+    }
+  }

--- a/docs/2023/IngMecanica.ts
+++ b/docs/2023/IngMecanica.ts
@@ -1,0 +1,283 @@
+import { RegimenCorrelatividades } from "../interfaces/regimen";
+
+export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
+      "carrera": "Ingeniería Mecánica",
+      "plan": "2023",
+      "regimen_correlatividades": [
+        {
+          "nivel": "I",
+          "asignaturas": [
+            {
+              "numero": 1,
+              "nombre": "ANÁLISIS MATEMÁTICO I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 2,
+              "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 3,
+              "nombre": "INGENIERÍA Y SOCIEDAD",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 4,
+              "nombre": "INGENIERÍA MECÁNICA I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 5,
+              "nombre": "SISTEMAS DE REPRESENTACIÓN",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 6,
+              "nombre": "FÍSICA I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 7,
+              "nombre": "QUÍMICA GENERAL",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 8,
+              "nombre": "INGENIERÍA AMBIENTAL Y SEGURIDAD INDUSTRIAL",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [7, 6]
+            },
+            {
+              "numero": 9,
+              "nombre": "FUNDAMENTOS DE INFORMÁTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            },
+            {
+              "numero": 10,
+              "nombre": "INGLÉS I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": []
+            }
+          ]
+        },
+        {
+          "nivel": "II",
+          "asignaturas": [
+            {
+              "numero": 11,
+              "nombre": "ANÁLISIS MATEMÁTICO II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2]
+            },
+            {
+              "numero": 12,
+              "nombre": "ESTABILIDAD I",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2, 6]
+            },
+            {
+              "numero": 13,
+              "nombre": "MATERIALES NO METÁLICOS",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [7, 6]
+            },
+            {
+              "numero": 14,
+              "nombre": "MATERIALES METÁLICOS",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [7, 6]
+            },
+            {
+              "numero": 15,
+              "nombre": "FÍSICA II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 6]
+            },
+            {
+              "numero": 16,
+              "nombre": "INGENIERÍA MECÁNICA II",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [15, 4]
+            },
+            {
+              "numero": 17,
+              "nombre": "PROBABILIDAD Y ESTADÍSTICA",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1, 2]
+            },
+            {
+              "numero": 18,
+              "nombre": "INGLÉS II",
+              "para_cursar_aprobar": [10],
+              "para_cursar_cursar": []
+            }
+          ]
+        },
+        {
+          "nivel": "III",
+          "asignaturas": [
+            {
+              "numero": 19,
+              "nombre": "TERMODINÁMICA",
+              "para_cursar_aprobar": [1, 2, 6],
+              "para_cursar_cursar": [11, 15]
+            },
+            {
+              "numero": 20,
+              "nombre": "MECÁNICA RACIONAL",
+              "para_cursar_aprobar": [1, 2, 6],
+              "para_cursar_cursar": [12, 11]
+            },
+            {
+              "numero": 21,
+              "nombre": "ESTABILIDAD II",
+              "para_cursar_aprobar": [1, 2, 6],
+              "para_cursar_cursar": [12, 11]
+            },
+            {
+              "numero": 22,
+              "nombre": "MEDICIONES Y ENSAYOS",
+              "para_cursar_aprobar": [1, 6],
+              "para_cursar_cursar": [12, 14, 15]
+            },
+            {
+              "numero": 23,
+              "nombre": "DISEÑO MECÁNICO",
+              "para_cursar_aprobar": [6, 4, 5, 9],
+              "para_cursar_cursar": [13, 12, 14]
+            },
+            {
+              "numero": 24,
+              "nombre": "INGENIERÍA MECÁNICA III",
+              "para_cursar_aprobar": [1, 7, 6, 4],
+              "para_cursar_cursar": [13, 14, 16]
+            },
+            {
+              "numero": 25,
+              "nombre": "CÁLCULO AVANZADO",
+              "para_cursar_aprobar": [1, 2],
+              "para_cursar_cursar": [11, 9]
+            },
+            {
+              "numero": 26,
+              "nombre": "ELECTROTECNIA Y MÁQUINAS ELÉCTRICAS",
+              "para_cursar_aprobar": [1, 2, 6],
+              "para_cursar_cursar": [11, 15]
+            },
+            {
+              "numero": 27,
+              "nombre": "PROCESOS DE MANUFACTURA",
+              "para_cursar_aprobar": [1, 7, 6, 4],
+              "para_cursar_cursar": [13, 14, 16]
+            }
+          ]
+        },
+        {
+          "nivel": "IV",
+          "asignaturas": [
+            {
+              "numero": 28,
+              "nombre": "ECONOMÍA",
+              "para_cursar_aprobar": [3],
+              "para_cursar_cursar": [16]
+            },
+            {
+              "numero": 29,
+              "nombre": "ELEMENTOS DE MÁQUINAS",
+              "para_cursar_aprobar": [7, 12, 11],
+              "para_cursar_cursar": [13, 14, 20, 21, 24]
+            },
+            {
+              "numero": 30,
+              "nombre": "TECNOLOGÍA DEL CALOR",
+              "para_cursar_aprobar": [11, 15],
+              "para_cursar_cursar": [19]
+            },
+            {
+              "numero": 31,
+              "nombre": "METROLOGÍA E INGENIERÍA DE CALIDAD",
+              "para_cursar_aprobar": [2, 14, 15],
+              "para_cursar_cursar": [22, 17]
+            },
+            {
+              "numero": 32,
+              "nombre": "MECÁNICA DE LOS FLUIDOS",
+              "para_cursar_aprobar": [11, 15],
+              "para_cursar_cursar": [19]
+            },
+            {
+              "numero": 33,
+              "nombre": "ELECTRÓNICA Y SISTEMAS DE CONTROL",
+              "para_cursar_aprobar": [1, 2, 6],
+              "para_cursar_cursar": [11, 15, 25]
+            },
+            {
+              "numero": 34,
+              "nombre": "ESTABILIDAD III",
+              "para_cursar_aprobar": [1, 2, 6, 12],
+              "para_cursar_cursar": [21]
+            },
+            {
+              "numero": 35,
+              "nombre": "LEGISLACIÓN",
+              "para_cursar_aprobar": [3],
+              "para_cursar_cursar": [16]
+            }
+          ]
+        },
+        {
+          "nivel": "V",
+          "asignaturas": [
+            {
+              "numero": 36,
+              "nombre": "TECNOLOGÍA DE LA FABRICACIÓN",
+              "para_cursar_aprobar": [13, 12, 14, 23],
+              "para_cursar_cursar": [29, 31]
+            },
+            {
+              "numero": 37,
+              "nombre": "MÁQUINAS ALTERNATIVAS Y TURBOMÁQUINAS",
+              "para_cursar_aprobar": [15, 19],
+              "para_cursar_cursar": [30]
+            },
+            {
+              "numero": 38,
+              "nombre": "INSTALACIONES INDUSTRIALES",
+              "para_cursar_aprobar": [12, 8],
+              "para_cursar_cursar": [22, 30, 32, 26, 33, 19]
+            },
+            {
+              "numero": 39,
+              "nombre": "ORGANIZACIÓN INDUSTRIAL",
+              "para_cursar_aprobar": [16],
+              "para_cursar_cursar": [28]
+            },
+            {
+              "numero": 40,
+              "nombre": "MANTENIMIENTO",
+              "para_cursar_aprobar": [14, 15, 20, 12],
+              "para_cursar_cursar": [22, 28, 29]
+            },
+            {
+              "numero": 41,
+              "nombre": "PROYECTO FINAL",
+              "para_cursar_aprobar": [20, 21, 22, 23],
+              "para_cursar_cursar": [29, 31, 26, 33]
+            }
+          ]
+        }
+      ],
+      "condiciones_adicionales": {
+        "proyecto_final": "Ninguna condición adicional explícita para Proyecto Final más allá de las correlatividades de la asignatura.",
+        "practica_profesional_supervisada": "No se especifica información adicional para la Práctica Profesional Supervisada."
+      }
+    }


### PR DESCRIPTION
This pull request adds detailed curricular plans for three engineering programs (`Ingeniería Civil`, `Ingeniería Eléctrica`, and `Ingeniería Electrónica`) to the repository. Each plan outlines the courses, their prerequisites, and additional conditions for graduation. 

### Curricular Plans Added:

#### Ingeniería Civil:
* Added `plan_ing_civil_2023` with a comprehensive structure of courses organized by levels (I-V), specifying prerequisites for each course and additional conditions for the final project and professional practice. (`docs/2023/IngCivil.ts`)

#### Ingeniería Eléctrica:
* Added `plan_ing_electrica_2025` with a detailed breakdown of courses by levels (I-V), including prerequisites and specific graduation requirements for the final project and professional practice. (`docs/2023/IngElectrica.ts`)

#### Ingeniería Electrónica:
* Added `plan_ing_electronica_2023` with courses categorized by levels (I-V), prerequisites, and conditions for the final project and professional practice. (`docs/2023/IngElectronica.ts`)