### PR TITLE
FIX - Study Plans

### DIFF
--- a/docs/2023/IngCivil.ts
+++ b/docs/2023/IngCivil.ts
@@ -1,4 +1,4 @@
-import { RegimenCorrelatividades } from "../interfaces/regimen";
+import { RegimenCorrelatividades } from "./interfaces/regimen";
 
 export const plan_ing_civil_2023: RegimenCorrelatividades = {
     "carrera": "Ingeniería Civil",

--- a/docs/2023/IngCivil.ts
+++ b/docs/2023/IngCivil.ts
@@ -1,279 +1,279 @@
-import { RegimenCorrelatividades } from "./interfaces/regimen";
+import { RegimenCorrelatividades } from "../interfaces/regimen";
 
 export const plan_ing_civil_2023: RegimenCorrelatividades = {
     "carrera": "Ingeniería Civil",
     "plan": "2023",
       "regimen_correlatividades": [
         {
-          "nivel": "I",
-          "asignaturas": [
-            {
-              "numero": 1,
-              "nombre": "ANÁLISIS MATEMÁTICO I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 2,
-              "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 3,
-              "nombre": "INGENIERÍA Y SOCIEDAD",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 4,
-              "nombre": "INGENIERÍA CIVIL I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 5,
-              "nombre": "SISTEMAS DE REPRESENTACIÓN",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 6,
-              "nombre": "FÍSICA I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 7,
-              "nombre": "QUÍMICA GENERAL",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 8,
-              "nombre": "INGLÉS I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 9,
-              "nombre": "FUNDAMENTOS DE INFORMÁTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            }
-          ]
-        },
-        {
-          "nivel": "II",
-          "asignaturas": [
-            {
-              "numero": 10,
-              "nombre": "ANÁLISIS MATEMÁTICO II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2]
-            },
-            {
-              "numero": 11,
-              "nombre": "ESTABILIDAD",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2, 5, 6, 9]
-            },
-            {
-              "numero": 12,
-              "nombre": "INGENIERÍA CIVIL II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [3, 4, 5, 9]
-            },
-            {
-              "numero": 13,
-              "nombre": "TECNOLOGÍA DE LOS MATERIALES",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 5, 7, 6]
-            },
-            {
-              "numero": 14,
-              "nombre": "FÍSICA II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 6]
-            },
-            {
-              "numero": 15,
-              "nombre": "PROBABILIDAD Y ESTADÍSTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2]
-            }
-          ]
-        },
-        {
-          "nivel": "III",
-          "asignaturas": [
-            {
-              "numero": 16,
-              "nombre": "RESISTENCIA DE LOS MATERIALES",
-              "para_cursar_aprobar": [1, 2, 6, 9],
-              "para_cursar_cursar": [11]
-            },
-            {
-              "numero": 17,
-              "nombre": "TECNOLOGÍA DEL HORMIGÓN",
-              "para_cursar_aprobar": [1, 2, 7, 6],
-              "para_cursar_cursar": [13, 15, 8]
-            },
-            {
-              "numero": 18,
-              "nombre": "TECNOLOGÍA DE LA CONSTRUCCIÓN",
-              "para_cursar_aprobar": [1, 2, 4, 5, 7, 6, 9],
-              "para_cursar_cursar": [11, 12, 13, 8]
-            },
-            {
-              "numero": 19,
-              "nombre": "INSTALACIONES TERMOMECÁNICAS",
-              "para_cursar_aprobar": [1, 2, 4, 5, 7, 6],
-              "para_cursar_cursar": [12, 13, 14]
-            },
-            {
-              "numero": 20,
-              "nombre": "GEOTOPOGRAFÍA",
-              "para_cursar_aprobar": [1, 2, 4, 5, 6],
-              "para_cursar_cursar": [10, 12, 14, 15]
-            },
-            {
-              "numero": 21,
-              "nombre": "HIDRÁULICA GENERAL Y APLICADA",
-              "para_cursar_aprobar": [1, 2, 5, 6, 9],
-              "para_cursar_cursar": [10, 11, 12, 14, 15]
-            },
-            {
-              "numero": 22,
-              "nombre": "CÁLCULO AVANZADO",
-              "para_cursar_aprobar": [1, 2, 5, 6, 9],
-              "para_cursar_cursar": [10, 11, 13, 15]
-            },
-            {
-              "numero": 23,
-              "nombre": "INSTALACIONES ELÉCTRICAS Y ACÚSTICAS",
-              "para_cursar_aprobar": [1, 2, 4, 5, 7, 6],
-              "para_cursar_cursar": [12, 13, 14]
-            },
-            {
-              "numero": 24,
-              "nombre": "ECONOMÍA",
-              "para_cursar_aprobar": [1, 2, 3, 4, 9],
-              "para_cursar_cursar": [12, 15, 8]
-            },
-            {
-              "numero": 25,
-              "nombre": "INGLÉS TÉCNICO II",
-              "para_cursar_aprobar": [3, 4],
-              "para_cursar_cursar": [8]
-            }
-          ]
-        },
-        {
-          "nivel": "IV",
-          "asignaturas": [
-            {
-              "numero": 26,
-              "nombre": "GEOTECNIA",
-              "para_cursar_aprobar": [10, 11, 12, 13, 14, 15],
-              "para_cursar_cursar": [16, 17, 18, 20, 21]
-            },
-            {
-              "numero": 27,
-              "nombre": "INSTALACIONES SANITARIAS Y DE GAS",
-              "para_cursar_aprobar": [5, 7, 6, 9, 13],
-              "para_cursar_cursar": [18, 20, 21, 24]
-            },
-            {
-              "numero": 28,
-              "nombre": "ANÁLISIS ESTRUCTURAL I",
-              "para_cursar_aprobar": [10, 12, 11, 15],
-              "para_cursar_cursar": [16, 17]
-            },
-            {
-              "numero": 29,
-              "nombre": "DISEÑO ARQ. PLANEAMIENTO Y URBANISMO I",
-              "para_cursar_aprobar": [11, 12, 13, 8],
-              "para_cursar_cursar": [18, 20, 23, 19, 24, 25]
-            },
-            {
-              "numero": 30,
-              "nombre": "ESTRUCTURAS DE HORMIGÓN",
-              "para_cursar_aprobar": [10, 11, 12, 13, 14, 15],
-              "para_cursar_cursar": [16, 17, 18, 20, 25]
-            },
-            {
-              "numero": 31,
-              "nombre": "HIDROLOGÍA Y OBRAS HIDRÁULICAS",
-              "para_cursar_aprobar": [10, 11, 12, 13, 14, 15],
-              "para_cursar_cursar": [16, 18, 20, 21, 24, 25]
-            },
-            {
-              "numero": 32,
-              "nombre": "INGENIERÍA LEGAL",
-              "para_cursar_aprobar": [1, 2, 3, 4, 9],
-              "para_cursar_cursar": [10, 12, 15]
-            }
-          ]
-        },
-        {
-          "nivel": "V",
-          "asignaturas": [
-            {
-              "numero": 33,
-              "nombre": "CONSTRUCCIONES METÁLICAS Y DE MADERA",
-              "para_cursar_aprobar": [16, 17, 18, 20],
-              "para_cursar_cursar": [22, 28]
-            },
-            {
-              "numero": 34,
-              "nombre": "CIMENTACIONES",
-              "para_cursar_aprobar": [16, 17, 18, 20, 21],
-              "para_cursar_cursar": [22, 26, 28, 30, 31]
-            },
-            {
-              "numero": 35,
-              "nombre": "ORGANIZACIÓN Y CONDUCCIÓN DE OBRAS",
-              "para_cursar_aprobar": [17, 18, 20, 21, 23, 19, 24, 25],
-              "para_cursar_cursar": [26, 27, 29, 30, 31]
-            },
-            {
-              "numero": 36,
-              "nombre": "VIAS DE COMUNICACIÓN I",
-              "para_cursar_aprobar": [10, 11, 12, 13, 15, 8],
-              "para_cursar_cursar": [17, 18, 20]
-            },
-            {
-              "numero": 37,
-              "nombre": "ANÁLISIS ESTRUCTURAL II",
-              "para_cursar_aprobar": [16, 17, 18, 20, 25],
-              "para_cursar_cursar": [22, 26, 28, 30, 31]
-            },
-            {
-              "numero": 38,
-              "nombre": "INGENIERÍA SANITARIA",
-              "para_cursar_aprobar": [17, 18, 20, 21, 25],
-              "para_cursar_cursar": [26, 27, 31]
-            },
-            {
-              "numero": 39,
-              "nombre": "VIAS DE COMUNICACIÓN II",
-              "para_cursar_aprobar": [16, 17, 18, 20, 21, 24],
-              "para_cursar_cursar": [26, 30, 31, 32, 36]
-            },
-            {
-              "numero": 40,
-              "nombre": "GESTIÓN AMBIENTAL Y DESARROLLO SUSTENTABLE",
-              "para_cursar_aprobar": [21, 24, 25],
-              "para_cursar_cursar": [26, 29, 31, 32]
-            },
-            {
-              "numero": 41,
-              "nombre": "PROYECTO FINAL",
-              "para_cursar_aprobar": [8, 16, 17, 18, 20, 21, 24, 23, 19, 25],
-              "para_cursar_cursar": [26, 27, 32, 29, 28, 30, 31]
-            }
-          ]
+  "nivel": "I",
+  "asignaturas": [
+    {
+      "numero": 1,
+      "nombre": "Análisis Matemático I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 2,
+      "nombre": "Álgebra y Geometría Analítica",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 3,
+      "nombre": "Ingeniería y Sociedad",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 4,
+      "nombre": "Ingeniería Civil I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 5,
+      "nombre": "Sistemas de Representación",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 6,
+      "nombre": "Química General",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 7,
+      "nombre": "Física I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 8,
+      "nombre": "Fundamentos de Informática",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    }
+  ]
+},
+{
+  "nivel": "II",
+  "asignaturas": [
+    {
+      "numero": 9,
+      "nombre": "Análisis Matemático II",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [1, 2]
+    },
+    {
+      "numero": 10,
+      "nombre": "Estabilidad",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [1, 2,5,8],
+    },
+    {
+      "numero": 11,
+      "nombre": "Ingeniería Civil II",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [3,4,5,8]
+    },
+    {
+      "numero": 12,
+      "nombre": "Tecnología de los Materiales",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [1,5,6,7]
+    },
+    {
+      "numero": 13,
+      "nombre": "Fisica II",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [1, 7]
+    },
+    {
+      "numero": 14,
+      "nombre": "Probabilidad y Estadística",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [1, 2]
+    },
+    {
+      "numero": 15,
+      "nombre": "Inglés I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": [3]
+    }
+  ]
+},
+{
+  "nivel": "III",
+  "asignaturas": [
+    {
+      "numero": 16,
+      "nombre": "Resistencia de los Materiales",
+      "para_cursar_aprobar": [10],
+      "para_cursar_cursar": [1, 2, 7, 9]
+    },
+    {
+      "numero": 17,
+      "nombre": "Tecnología del Hormigón",
+      "para_cursar_aprobar": [1,2,6,7],
+      "para_cursar_cursar": [12,14,15]
+    },
+    {
+      "numero": 18,
+      "nombre": "Tecnología de la Construcción",
+      "para_cursar_aprobar": [1,2,4,5,6,7],
+      "para_cursar_cursar": [10, 11,12,15]
+    },
+    {
+      "numero": 19,
+      "nombre": "Instalaciones Termomecánicas",
+      "para_cursar_aprobar": [1,2,4,5,6,7],
+      "para_cursar_cursar": [11,12,13]
+    },
+    {
+      "numero": 20,
+      "nombre": "Geotopografía",
+      "para_cursar_aprobar": [1,2,4,5,7],
+      "para_cursar_cursar": [9,11,13,14]
+    },
+    {
+      "numero": 21,
+      "nombre": "Hidráulica General y Aplicada",
+      "para_cursar_aprobar": [1,2,5,7,8],
+      "para_cursar_cursar": [9,10,11,13,14]
+    },
+    {
+      "numero": 22,
+      "nombre": "Cálculo Avanzado",
+      "para_cursar_aprobar": [9,10,12,14],
+      "para_cursar_cursar": [1,2,5,7,8]
+    },
+    {
+      "numero": 23,
+      "nombre": "Instalaciones Eléctricas y Acústicas",
+      "para_cursar_aprobar": [1,2,4,5,6,7],
+      "para_cursar_cursar": [11,12,13]
+    },
+    {
+      "numero": 24,
+      "nombre": "Economía",
+      "para_cursar_aprobar": [1,2,3,4,8],
+      "para_cursar_cursar": [11,14,15]
+    },
+    {
+      "numero": 25,
+      "nombre": "Inglés Técnico II",
+      "para_cursar_aprobar": [3],
+      "para_cursar_cursar": [15]
+    }
+  ]
+},
+{
+  "nivel": "IV",
+  "asignaturas": [
+    {
+      "numero": 26,
+      "nombre": "Geotecnia",
+      "para_cursar_aprobar": [9,10,11,12,13,14],
+      "para_cursar_cursar": [16, 17, 18, 20, 21]
+    },
+    {
+      "numero": 27,
+      "nombre": "Instalaciones Sanitarias y de Gas",
+      "para_cursar_aprobar": [5,6,7,8,12],
+      "para_cursar_cursar": [18,20,21,24]
+    },
+    {
+      "numero": 28,
+      "nombre": "Análisis Estructural I",
+      "para_cursar_aprobar": [9,11,10,14],
+      "para_cursar_cursar": [16,17]
+    },
+    {
+      "numero": 29,
+      "nombre": "Diseño Arq. Planeamiento y Urbanismo",
+      "para_cursar_aprobar": [18,20,23,19,24,25],
+      "para_cursar_cursar": [10,11,12,15]
+    },
+    {
+      "numero": 30,
+      "nombre": "Estructuras de Hormigón",
+      "para_cursar_aprobar": [16,17,18,20,25],
+      "para_cursar_cursar": [9,10,11,12,13,14,15]
+    },
+    {
+      "numero": 31,
+      "nombre": "Hidrología y Obras Hidráulicas",
+      "para_cursar_aprobar": [16,1820,21,24,25],
+      "para_cursar_cursar": [9,10,11,12,13,14]
+    },
+    {
+      "numero": 32,
+      "nombre": "Ingeniería Legal",
+      "para_cursar_aprobar": [1,2,3,4,8],
+      "para_cursar_cursar": [9,11,14,15]
+    }
+  ]
+},
+{
+  "nivel": "V",
+  "asignaturas": [
+    {
+      "numero": 33,
+      "nombre": "Construcciones Metálicas y de Madera",
+      "para_cursar_aprobar": [16,17,18,20],
+      "para_cursar_cursar": [22, 28]
+    },
+    {
+      "numero": 34,
+      "nombre": "Cimentaciones",
+      "para_cursar_aprobar": [16,17,18,20,21],
+      "para_cursar_cursar": [22,26,28,30,31]
+    },
+    {
+      "numero": 35,
+      "nombre": "Organización y Conducción de Obras",
+      "para_cursar_aprobar": [17,18,20,21,23,19,24,25],
+      "para_cursar_cursar": [26,27,29,30,31]
+    },
+    {
+      "numero": 36,
+      "nombre": "Vías de Comunicación I",
+      "para_cursar_aprobar": [9,10,11,12,14,15],
+      "para_cursar_cursar": [17,18,20]
+    },
+    {
+      "numero": 37,
+      "nombre": "Análisis Estructural II",
+      "para_cursar_aprobar": [16,17,18,20,25],
+      "para_cursar_cursar": [22,26,28,30,31]
+    },
+    {
+      "numero": 38,
+      "nombre": "Ingeniería Sanitaria",
+      "para_cursar_aprobar": [17,18,20,21,25],
+      "para_cursar_cursar": [26,27,31]
+    },
+    {
+      "numero": 39,
+      "nombre": "Vías de Comunicación II",
+      "para_cursar_aprobar": [16,17,18,20,21,24],
+      "para_cursar_cursar": [26,30,31,32,36]
+    },
+    {
+      "numero": 40,
+      "nombre": "Gestión Ambiental y Desarrollo Sustentable",
+      "para_cursar_aprobar": [24,25,21],
+      "para_cursar_cursar": [26,29,31,32]
+    },
+    {
+      "numero": 41,
+      "nombre": "Proyecto Final",
+      "para_cursar_aprobar": [15,16,17,18,20,21,24,23,19,25],
+      "para_cursar_cursar": [26,27,32,29,28,30,31]
+    }      
+       ]
         }
       ],
       "condiciones_adicionales": {

--- a/docs/2023/IngElectrica.ts
+++ b/docs/2023/IngElectrica.ts
@@ -1,289 +1,288 @@
-import { RegimenCorrelatividades } from "./interfaces/regimen";
+import { RegimenCorrelatividades } from "../interfaces/regimen";
 
 export const plan_ing_electrica_2025: RegimenCorrelatividades = {
     "carrera": "Ingeniería Eléctrica",
-    "plan": "2025a",
+    "plan": "2023",
     "regimen_correlatividades": [
       {
-        "nivel": "I",
-        "asignaturas": [
-          {
-            "numero": 1,
-            "nombre": "ANÁLISIS MATEMÁTICO I",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 2,
-            "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 3,
-            "nombre": "INGENIERÍA Y SOCIEDAD",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 4,
-            "nombre": "INTEGRACIÓN ELÉCTRICA I",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 5,
-            "nombre": "SISTEMAS DE REPRESENTACIÓN",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 6,
-            "nombre": "FÍSICA I",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 7,
-            "nombre": "QUÍMICA GENERAL",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 8,
-            "nombre": "FÍSICA",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 9,
-            "nombre": "FUNDAMENTOS DE INFORMÁTICA",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 10,
-            "nombre": "INGLÉS I",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          }
-        ]
-      },
+        
+  "nivel": "I",
+  "asignaturas": [
+    {
+      "numero": 1,
+      "nombre": "Análisis Matemático I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 2,
+      "nombre": "Álgebra y Geometría Analítica",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 3,
+      "nombre": "Ingeniería y Sociedad",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 4,
+      "nombre": "Integración Eléctrica I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 5,
+      "nombre": "Sistemas de Representación",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 6,
+      "nombre": "Química General",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 7,
+      "nombre": "Física I",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    },
+    {
+      "numero": 8,
+      "nombre": "Fundamentos de Informática",
+      "para_cursar_aprobar": [],
+      "para_cursar_cursar": []
+    }
+  ]
+},
       {
         "nivel": "II",
         "asignaturas": [
-          {
-            "numero": 11,
-            "nombre": "ANÁLISIS MATEMÁTICO II",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 2]
-          },
-          {
-            "numero": 12,
-            "nombre": "ESTABILIDAD",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 2, 6]
-          },
-          {
-            "numero": 13,
-            "nombre": "INTEGRACIÓN ELÉCTRICA II",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 6, 4]
-          },
-          {
-            "numero": 14,
-            "nombre": "ELECTROTECNIA I",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 2, 6]
-          },
-          {
-            "numero": 15,
-            "nombre": "FÍSICA II",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 6]
-          },
-          {
-            "numero": 16,
-            "nombre": "MECÁNICA TÉCNICA",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 6]
-          },
-          {
-            "numero": 17,
-            "nombre": "CÁLCULO NUMÉRICO",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 2, 6, 9]
-          },
-          {
-            "numero": 18,
-            "nombre": "PROBABILIDAD Y ESTADÍSTICA",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [1, 2]
-          },
-          {
-            "numero": 19,
-            "nombre": "TALLER INTERDISCIPLINARIO",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 20,
-            "nombre": "FUNDAMENTOS PARA EL ANÁLISIS DE SEÑALES",
-            "para_cursar_aprobar": [1, 2],
-            "para_cursar_cursar": [11, 17]
-          }
-        ]
+       {
+        "numero": 9,
+        "nombre": "Análisis Matemático II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2]
       },
       {
-        "nivel": "III",
-        "asignaturas": [
-          {
-            "numero": 21,
-            "nombre": "TECNOLOGÍAS Y ENSAYOS DE MATERIALES ELÉCTRICOS",
-            "para_cursar_aprobar": [1, 6],
-            "para_cursar_cursar": [7, 15]
-          },
-          {
-            "numero": 22,
-            "nombre": "INSTRUMENTOS Y MEDICIONES ELÉCTRICAS",
-            "para_cursar_aprobar": [1, 2, 6],
-            "para_cursar_cursar": [18, 14]
-          },
-          {
-            "numero": 23,
-            "nombre": "TEORÍA DE LOS CAMPOS",
-            "para_cursar_aprobar": [1, 2, 6],
-            "para_cursar_cursar": [15, 11]
-          },
-          {
-            "numero": 24,
-            "nombre": "FÍSICA III",
-            "para_cursar_aprobar": [1, 2, 6],
-            "para_cursar_cursar": [15, 11]
-          },
-          {
-            "numero": 25,
-            "nombre": "MÁQUINAS ELÉCTRICAS I",
-            "para_cursar_aprobar": [1, 6],
-            "para_cursar_cursar": [15, 14, 11, 17]
-          },
-          {
-            "numero": 26,
-            "nombre": "ELECTROTECNIA II",
-            "para_cursar_aprobar": [1, 2, 6],
-            "para_cursar_cursar": [15, 14, 11]
-          },
-          {
-            "numero": 27,
-            "nombre": "TERMODINÁMICA",
-            "para_cursar_aprobar": [1, 2, 6],
-            "para_cursar_cursar": [15, 11]
-          },
-          {
-            "numero": 28,
-            "nombre": "SEGURIDAD, RIESGO ELÉCTRICO Y MEDIO AMBIENTE",
-            "para_cursar_aprobar": [1, 2, 6, 15, 11],
-            "para_cursar_cursar": [7, 14, 21, 23]
-          },
-          {
-            "numero": 29,
-            "nombre": "INSTALACIONES ELÉCTRICAS Y LUMINOTECNIA",
-            "para_cursar_aprobar": [7, 6, 14, 13, 10, 11],
-            "para_cursar_cursar": [21, 25, 26]
-          },
-          {
-            "numero": 30,
-            "nombre": "INGLÉS II",
-            "para_cursar_aprobar": [10],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 31,
-            "nombre": "ECONOMÍA",
-            "para_cursar_aprobar": [3],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 32,
-            "nombre": "LEGISLACIÓN",
-            "para_cursar_aprobar": [3],
-            "para_cursar_cursar": []
-          }
-        ]
+        "numero": 10,
+        "nombre": "Estabilidad",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2, 7]
       },
+      {
+        "numero": 11,
+        "nombre": "Integración Eléctrica II",
+        "para_cursar_aprobar": [4],
+        "para_cursar_cursar": [1,7,4]
+      },
+      {
+        "numero": 12,
+        "nombre": "Electrotecnia I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2, 7]
+      },
+      {
+        "numero": 13,
+        "nombre": "Física II",
+        "para_cursar_aprobar": [1, 2, 7],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 14,
+        "nombre": "Probabilidad y Estadística",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2]
+      },
+      {
+        "numero": 15,
+        "nombre": "Mecánica Técnica",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1,  7]
+      },
+      {
+        "numero": 16,
+        "nombre": "Cálculo Numérico",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2, 7, 8]
+      },
+      {
+        "numero": 17,
+        "nombre": "Inglés I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      }
+    ]
+  },
+  {
+    "nivel": "III",
+    "asignaturas": [
+      {
+        "numero": 18,
+        "nombre": "Tecnologías y Ensayos de Materiales Eléctricos",
+        "para_cursar_aprobar": [1,7],
+        "para_cursar_cursar": [6,13]
+      },
+      {
+        "numero": 19,
+        "nombre": "Instrumentos y Mediciones Eléctricas",
+        "para_cursar_aprobar": [1, 2, 7],
+        "para_cursar_cursar": [12,14]
+      },
+      {
+        "numero": 20,
+        "nombre": "Teoría de los Campos",
+        "para_cursar_aprobar": [1, 2, 7],
+        "para_cursar_cursar": [9,13]
+      },
+      {
+        "numero": 21,
+        "nombre": "Física III",
+        "para_cursar_aprobar": [1, 2, 9],
+        "para_cursar_cursar": [9,13]
+      },
+      {
+        "numero": 22,
+        "nombre": "Máquinas Eléctricas I",
+        "para_cursar_aprobar": [1,7],
+        "para_cursar_cursar": [9,13,12,16]
+      },
+      {
+        "numero": 23,
+        "nombre": "Electrotecnia II",
+        "para_cursar_aprobar": [1, 2,7],
+        "para_cursar_cursar": [9,12,13]
+      },
+      {
+        "numero": 24,
+        "nombre": "Termodinámica",
+        "para_cursar_aprobar": [1, 2, 7],
+        "para_cursar_cursar": [9,13]
+      },
+      {
+        "numero": 25,
+        "nombre": "Fundamentos para el Análisis de Señales",
+        "para_cursar_aprobar": [1, 2],
+        "para_cursar_cursar": [9,16]
+      },
+      {
+        "numero": 26,
+        "nombre": "Taller Interdisciplinario",
+        "para_cursar_aprobar": [1,7],
+        "para_cursar_cursar": [9,13,12,16]
+      }
+    ]
+  
+      },
+     
       {
         "nivel": "IV",
         "asignaturas": [
-          {
-            "numero": 33,
-            "nombre": "ELECTRÓNICA I",
-            "para_cursar_aprobar": [1, 6],
-            "para_cursar_cursar": [14]
-          },
-          {
-            "numero": 34,
-            "nombre": "MÁQUINAS ELÉCTRICAS II",
-            "para_cursar_aprobar": [7, 15, 18, 14, 10, 11],
-            "para_cursar_cursar": [21, 22, 23, 25, 26]
-          },
-          {
-            "numero": 35,
-            "nombre": "CONTROL AUTOMÁTICO",
-            "para_cursar_aprobar": [14, 11],
-            "para_cursar_cursar": [26, 20]
-          },
-          {
-            "numero": 36,
-            "nombre": "MÁQUINAS TÉRMICAS, HIDRÁULICAS Y DE FLUIDO",
-            "para_cursar_aprobar": [15, 11],
-            "para_cursar_cursar": [12, 16, 27]
-          }
+           {
+        "numero": 27,
+        "nombre": "Electronica I",
+        "para_cursar_aprobar": [1,2],
+        "para_cursar_cursar": [12]
+      },
+      {
+        "numero": 28,
+        "nombre": "Máquinas Eléctricas II",
+        "para_cursar_aprobar": [6,13,14,12,17,9],
+        "para_cursar_cursar": [18,19,20,22,23]
+      },
+      {
+        "numero": 29,
+        "nombre": "Seguridad,Riesgo Eléctrico y Medio Ambiente",
+        "para_cursar_aprobar": [1,2,7,13,9],
+        "para_cursar_cursar": [6,12,18,20]
+      },
+      {
+        "numero": 30,
+        "nombre": "Instalaciones Eléctricas Y Luminoctenia",
+        "para_cursar_aprobar": [6,13,12,11,17,9],
+        "para_cursar_cursar": [18,22,23]
+      },
+      {
+        "numero": 31,
+        "nombre": "Control Automático",
+        "para_cursar_aprobar": [9,12],
+        "para_cursar_cursar": [23,25]
+      },
+      {
+        "numero": 32,
+        "nombre": "Máquinas Térmicas, Hidráulicas y de Fluido",
+        "para_cursar_aprobar": [9, 13],
+        "para_cursar_cursar": [10,15,24]
+      },
+      {
+        "numero": 33,
+        "nombre": "Inglés II",
+        "para_cursar_aprobar": [17],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 34,
+        "nombre": "Economía",
+        "para_cursar_aprobar": [3],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 35,
+        "nombre": "Legislación",
+        "para_cursar_aprobar": [3],
+        "para_cursar_cursar": []
+      }
         ]
       },
       {
         "nivel": "V",
         "asignaturas": [
           {
-            "numero": 37,
-            "nombre": "GENERACIÓN, TRANSMISIÓN Y DISTRIBUCIÓN DE LA ENERGÍA ELÉCTRICA",
-            "para_cursar_aprobar": [12, 16, 21, 25, 26, 27],
-            "para_cursar_cursar": [24, 34, 36]
-          },
-          {
-            "numero": 38,
-            "nombre": "ELECTRÓNICA II",
-            "para_cursar_aprobar": [14, 19],
-            "para_cursar_cursar": [26, 33]
-          },
-          {
-            "numero": 39,
-            "nombre": "SISTEMAS DE POTENCIA",
-            "para_cursar_aprobar": [21, 25, 26, 19],
-            "para_cursar_cursar": [34, 35]
-          },
-          {
-            "numero": 40,
-            "nombre": "ACCIONAMIENTOS Y CONTROLES ELÉCTRICOS",
-            "para_cursar_aprobar": [14, 21, 25, 26, 20, 19],
-            "para_cursar_cursar": [33, 34, 35]
-          },
-          {
-            "numero": 41,
-            "nombre": "ORGANIZACIÓN Y ADMINISTRACIÓN DE EMPRESAS",
-            "para_cursar_aprobar": [19],
-            "para_cursar_cursar": [31, 32]
-          },
-          {
-            "numero": 42,
-            "nombre": "PROYECTO FINAL",
-            "para_cursar_aprobar": [21, 22, 25, 26, 20, 19, 30],
-            "para_cursar_cursar": [31, 34, 29, 35]
-          }
-        ]
+             "numero": 36,
+        "nombre": "Generación, Transmisión y Distribución de la Energía Eléctrica",
+        "para_cursar_aprobar": [10,15,18,22,23,24],
+        "para_cursar_cursar": [21,28,32]
+      },
+      {
+        "numero": 37,
+        "nombre": "Electrónica II",
+        "para_cursar_aprobar": [12,26],
+        "para_cursar_cursar": [23,27]
+      },
+      {
+        "numero": 38,
+        "nombre": "Sistemas De Potencia",
+        "para_cursar_aprobar": [18,22,23,26],
+        "para_cursar_cursar": [28,31]
+      },
+      {
+        "numero": 39,
+        "nombre": "Accionamiento y Controles Eléctricos",
+        "para_cursar_aprobar": [12,18,22,23,25,26],
+        "para_cursar_cursar": [27,28,31]
+      },
+      {
+        "numero": 40,
+        "nombre": "Organización y Administración de Empresas",
+        "para_cursar_aprobar": [34,35],
+        "para_cursar_cursar": [26]
+      },
+      {
+        "numero": 41,
+        "nombre": "Proyecto Final",
+        "para_cursar_aprobar": [18,19,22,23,25,26,33],
+        "para_cursar_cursar": [34,28,30,31]
       }
+    ]
+    }
+      
     ],
     "condiciones_adicionales": {
       "proyecto_final": "Es condición para iniciar y acreditar el Taller, el cumplimiento de los requisitos académicos exigidos para la inscripción a Máquinas Eléctricas I.  Ninguna condición adicional explícita para Proyecto Final más allá de las correlatividades de la asignatura. ",
       "practica_profesional_supervisada": "No se especifica información adicional para la Práctica Profesional Supervisada en el documento."
     }
   }
+  

--- a/docs/2023/IngElectrica.ts
+++ b/docs/2023/IngElectrica.ts
@@ -1,6 +1,6 @@
-import { RegimenCorrelatividades } from "../interfaces/regimen";
+import { RegimenCorrelatividades } from "./interfaces/regimen";
 
-export const plan_ing_electrica_2025: RegimenCorrelatividades = {
+export const plan_ing_electrica_2023: RegimenCorrelatividades = {
     "carrera": "Ingeniería Eléctrica",
     "plan": "2023",
     "regimen_correlatividades": [

--- a/docs/2023/IngElectronica.ts
+++ b/docs/2023/IngElectronica.ts
@@ -1,4 +1,4 @@
-import { RegimenCorrelatividades } from "./interfaces/regimen";
+import { RegimenCorrelatividades } from "../interfaces/regimen";
 
 export const plan_ing_electronica_2023: RegimenCorrelatividades = {
       "carrera": "Ingeniería Electrónica",
@@ -6,249 +6,249 @@ export const plan_ing_electronica_2023: RegimenCorrelatividades = {
       "regimen_correlatividades": [
         {
           "nivel": "I",
-          "asignaturas": [
-            {
-              "numero": 1,
-              "nombre": "ANÁLISIS MATEMÁTICO I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 2,
-              "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 3,
-              "nombre": "INGENIERÍA Y SOCIEDAD",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 4,
-              "nombre": "INFORMÁTICA I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 5,
-              "nombre": "FÍSICA I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 6,
-              "nombre": "INGLÉS I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [3]
-            },
-            {
-              "numero": 7,
-              "nombre": "DISEÑO ASISTIDO POR COMPUTADORA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            }
-          ]
-        },
-        {
-          "nivel": "II",
-          "asignaturas": [
-            {
-              "numero": 8,
-              "nombre": "QUÍMICA GENERAL",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 9,
-              "nombre": "INFORMÁTICA II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [4, 1, 2]
-            },
-            {
-              "numero": 10,
-              "nombre": "ANÁLISIS DE SEÑALES Y SISTEMAS",
-              "para_cursar_aprobar": [1, 2],
-              "para_cursar_cursar": [11]
-            },
-            {
-              "numero": 11,
-              "nombre": "FÍSICA II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 5]
-            },
-            {
-              "numero": 12,
-              "nombre": "LEGISLACIÓN",
-              "para_cursar_aprobar": [3],
-              "para_cursar_cursar": [9]
-            },
-            {
-              "numero": 13,
-              "nombre": "PROBABILIDAD Y ESTADÍSTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2]
-            },
-            {
-              "numero": 14,
-              "nombre": "ANÁLISIS MATEMÁTICO II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2]
-            },
-            {
-              "numero": 15,
-              "nombre": "FÍSICA ELECTRÓNICA",
-              "para_cursar_aprobar": [1, 2, 5],
-              "para_cursar_cursar": [11]
-            },
-            {
-              "numero": 16,
-              "nombre": "SEGURIDAD, HIGIENE Y MEDIO AMBIENTE",
-              "para_cursar_aprobar": [3, 8],
-              "para_cursar_cursar": []
-            }
-          ]
-        },
-        {
-          "nivel": "III",
-          "asignaturas": [
-            {
-              "numero": 17,
-              "nombre": "TEORÍA DE LOS CIRCUITOS I",
-              "para_cursar_aprobar": [1, 5],
-              "para_cursar_cursar": [14, 11]
-            },
-            {
-              "numero": 18,
-              "nombre": "TÉCNICAS DIGITALES I",
-              "para_cursar_aprobar": [2],
-              "para_cursar_cursar": [4]
-            },
-            {
-              "numero": 19,
-              "nombre": "DISPOSITIVOS ELECTRÓNICOS",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [4, 1, 8]
-            },
-            {
-              "numero": 20,
-              "nombre": "ELECTRÓNICA APLICADA I",
-              "para_cursar_aprobar": [4, 1, 5],
-              "para_cursar_cursar": [8, 11]
-            },
-            {
-              "numero": 21,
-              "nombre": "INGLÉS II",
-              "para_cursar_aprobar": [6],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 22,
-              "nombre": "MEDIOS DE ENLACE",
-              "para_cursar_aprobar": [1, 2, 5],
-              "para_cursar_cursar": [14, 11]
-            },
-            {
-              "numero": 23,
-              "nombre": "ECONOMÍA",
-              "para_cursar_aprobar": [3],
-              "para_cursar_cursar": [9]
-            }
-          ]
-        },
-        {
-          "nivel": "IV",
-          "asignaturas": [
-            {
-              "numero": 24,
-              "nombre": "TÉCNICAS DIGITALES II",
-              "para_cursar_aprobar": [8, 11],
-              "para_cursar_cursar": [9, 18, 20]
-            },
-            {
-              "numero": 25,
-              "nombre": "MEDIDAS ELECTRÓNICAS I",
-              "para_cursar_aprobar": [14, 8, 11],
-              "para_cursar_cursar": [10, 17, 18, 20]
-            },
-            {
-              "numero": 26,
-              "nombre": "TEORÍA DE LOS CIRCUITOS II",
-              "para_cursar_aprobar": [14, 11],
-              "para_cursar_cursar": [10, 17]
-            },
-            {
-              "numero": 27,
-              "nombre": "MÁQUINAS E INSTALACIONES ELÉCTRICAS",
-              "para_cursar_aprobar": [14, 11],
-              "para_cursar_cursar": [10, 17]
-            },
-            {
-              "numero": 28,
-              "nombre": "SISTEMAS DE COMUNICACIONES",
-              "para_cursar_aprobar": [14, 11],
-              "para_cursar_cursar": [10, 13, 20, 22]
-            },
-            {
-              "numero": 29,
-              "nombre": "ELECTRÓNICA APLICADA II",
-              "para_cursar_aprobar": [14, 11, 21],
-              "para_cursar_cursar": [10, 15, 17, 19, 20]
-            }
-          ]
-        },
-        {
-          "nivel": "V",
-          "asignaturas": [
-            {
-              "numero": 30,
-              "nombre": "TÉCNICAS DIGITALES III",
-              "para_cursar_aprobar": [9, 18, 20],
-              "para_cursar_cursar": [24]
-            },
-            {
-              "numero": 31,
-              "nombre": "MEDIDAS ELECTRÓNICAS II",
-              "para_cursar_aprobar": [7, 15, 17, 18, 20, 21],
-              "para_cursar_cursar": [24, 25, 28, 29]
-            },
-            {
-              "numero": 32,
-              "nombre": "SISTEMAS DE CONTROL",
-              "para_cursar_aprobar": [15, 17],
-              "para_cursar_cursar": [26, 27]
-            },
-            {
-              "numero": 33,
-              "nombre": "ELECTRÓNICA APLICADA III",
-              "para_cursar_aprobar": [15, 17, 20],
-              "para_cursar_cursar": [26, 28, 29]
-            },
-            {
-              "numero": 34,
-              "nombre": "TECNOLOGÍA ELECTRÓNICA",
-              "para_cursar_aprobar": [15, 18, 20],
-              "para_cursar_cursar": [25]
-            },
-            {
-              "numero": 35,
-              "nombre": "ELECTRÓNICA DE POTENCIA",
-              "para_cursar_aprobar": [15, 18, 20],
-              "para_cursar_cursar": [25, 27, 29]
-            },
-            {
-              "numero": 36,
-              "nombre": "ORGANIZACIÓN INDUSTRIAL",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [12]
-            },
-            {
-              "numero": 37,
-              "nombre": "PROYECTO FINAL",
-              "para_cursar_aprobar": [24, 25, 29],
-              "para_cursar_cursar": [30, 31, 33],
-            }
+    "asignaturas": [
+      {
+        "numero": 1,
+        "nombre": "Análisis Matemático I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 2,
+        "nombre": "Álgebra y Geometría Analítica",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 3,
+        "nombre": "Ingeniería y Sociedad",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 4,
+        "nombre": "Informática I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 5,
+        "nombre": "Diseño Asistido por Computadora",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 6,
+        "nombre": "Física I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 7,
+        "nombre": "Análisis Matemático II",
+        "para_cursar_aprobar": [ ],
+        "para_cursar_cursar": [1,2]
+      }
+    ]
+  },
+  {
+    "nivel": 2,
+    "asignaturas": [
+      {
+        "numero": 8,
+        "nombre": "Química General",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      },
+      {
+        "numero": 9,
+        "nombre": "Informática II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [4,1,2]
+      },
+      {
+        "numero": 10,
+        "nombre": "Análisis de Señales y Sistemas",
+        "para_cursar_aprobar": [1,2],
+        "para_cursar_cursar": [7]
+      },
+      {
+        "numero": 11,
+        "nombre": "Física II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1,6 ]
+      },
+      {
+        "numero": 12,
+        "nombre": "Probabilidad y Estadística",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1,2]
+      },
+      {
+        "numero": 13,
+        "nombre": "Inglés I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [3]
+      },
+      {
+        "numero": 14,
+        "nombre": "Física Electrónica",
+        "para_cursar_aprobar": [1,2,6],
+        "para_cursar_cursar": [11]
+      }
+    ]
+  },
+  {
+    "nivel": 3,
+    "asignaturas": [
+      {
+        "numero": 15,
+        "nombre": "Teoría de los Circuitos I",
+        "para_cursar_aprobar": [1,6],
+        "para_cursar_cursar": [7,11]
+      },
+      {
+        "numero": 16,
+        "nombre": "Técnicas Digitales I",
+        "para_cursar_aprobar": [2],
+        "para_cursar_cursar": [4]
+      },
+      {
+        "numero": 17,
+        "nombre": "Dispositivos Electrónicos",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [4,1,8]
+      },
+      {
+        "numero": 18,
+        "nombre": "Legislación",
+        "para_cursar_aprobar": [3],
+        "para_cursar_cursar": [9]
+      },
+      {
+        "numero": 19,
+        "nombre": "Electrónica Aplicada I",
+        "para_cursar_aprobar": [4,1,6],
+        "para_cursar_cursar": [8,11]
+      },
+      {
+        "numero": 20,
+        "nombre": "Medios de Enlace",
+        "para_cursar_aprobar": [1,2,6],
+        "para_cursar_cursar": [7,11]
+      },
+      {
+        "numero": 21,
+        "nombre": "Inglés II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [13]
+      }
+    ]
+  },
+  {
+    "nivel": 4,
+    "asignaturas": [
+      {
+        "numero": 22,
+        "nombre": "Técnicas Digitales II",
+        "para_cursar_aprobar": [8,11],
+        "para_cursar_cursar": [9,16,19]
+      },
+      {
+        "numero": 23,
+        "nombre": "Medidas Electrónicas I",
+        "para_cursar_aprobar": [7,8,11],
+        "para_cursar_cursar": [10,15,16,19]
+      },
+      {
+        "numero": 24,
+        "nombre": "Teoría de los Circuitos II",
+        "para_cursar_aprobar": [7,11],
+        "para_cursar_cursar": [10.15]
+      },
+      {
+        "numero": 25,
+        "nombre": "Máquinas e Instalaciones Eléctricas",
+        "para_cursar_aprobar": [7,11],
+        "para_cursar_cursar": [10,15]
+      },
+      {
+        "numero": 26,
+        "nombre": "Sistemas de Comunicaciones",
+        "para_cursar_aprobar": [7,11],
+        "para_cursar_cursar": [10,12,19,20]
+      },
+      {
+        "numero": 27,
+        "nombre": "Electrónica Aplicada II",
+        "para_cursar_aprobar": [7,11,13],
+        "para_cursar_cursar": [10,14,15,17,19]
+      },
+      {
+        "numero": 28,
+        "nombre": "Seguridad, Higiene y Medio Ambiente",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [3,8]
+      }
+    ]
+  },
+  {
+    "nivel": 5,
+    "asignaturas": [
+      {
+        "numero": 29,
+        "nombre": "Técnicas Digitales III",
+        "para_cursar_aprobar": [9,16,19],
+        "para_cursar_cursar": [22]
+      },
+      {
+        "numero": 30,
+        "nombre": "Medidas Electrónicas III",
+        "para_cursar_aprobar": [14,15,16,19,21],
+        "para_cursar_cursar": [22,23,26,27]
+      },
+      {
+        "numero": 31,
+        "nombre": "Sistemas de Control",
+        "para_cursar_aprobar": [14,15],
+        "para_cursar_cursar": [24,25]
+      },
+      {
+        "numero": 32,
+        "nombre": "Electrónica Aplicada III",
+        "para_cursar_aprobar": [14,15,19],
+        "para_cursar_cursar": [24,26,27]
+      },
+      {
+        "numero": 33,
+        "nombre": "Tecnología Electrónica",
+        "para_cursar_aprobar": [14,16,19],
+        "para_cursar_cursar": [23]
+      },
+      {
+        "numero": 34,
+        "nombre": "Electrónica de Potencia",
+        "para_cursar_aprobar": [14,16,19],
+        "para_cursar_cursar": [23,25,27]
+      },
+      {
+        "numero": 35,
+        "nombre": "Organización Industrial",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [18]
+      },
+      {
+        "numero": 36,
+        "nombre": "Economía",
+        "para_cursar_aprobar": [3],
+        "para_cursar_cursar": [8]
+      },
+      {
+        "numero": 37,
+        "nombre": "Proyecto Final",
+        "para_cursar_aprobar": [22,23,25,27],
+        "para_cursar_cursar": [29,30,32]
+      }
           ]
         }
       ],

--- a/docs/2023/IngElectronica.ts
+++ b/docs/2023/IngElectronica.ts
@@ -1,4 +1,4 @@
-import { RegimenCorrelatividades } from "../interfaces/regimen";
+import { RegimenCorrelatividades } from "./interfaces/regimen";
 
 export const plan_ing_electronica_2023: RegimenCorrelatividades = {
       "carrera": "Ingeniería Electrónica",

--- a/docs/2023/IngEnSistemas.ts
+++ b/docs/2023/IngEnSistemas.ts
@@ -1,6 +1,6 @@
-import { RegimenCorrelatividades } from "../interfaces/regimen";
+import { RegimenCorrelatividades } from "./interfaces/regimen";
 
-export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
+export const plan_ing_en_sistemas_2023: RegimenCorrelatividades = {
     "carrera": "Ingeniería en Sistemas de Información",
     "plan": "2023",
     "regimen_correlatividades": [

--- a/docs/2023/IngEnSistemas.ts
+++ b/docs/2023/IngEnSistemas.ts
@@ -1,11 +1,10 @@
-import { RegimenCorrelatividades } from "./interfaces/regimen";
+import { RegimenCorrelatividades } from "../interfaces/regimen";
 
 export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
     "carrera": "Ingeniería en Sistemas de Información",
     "plan": "2023",
     "regimen_correlatividades": [
-      {
-        "nivel": 1,
+      { "nivel": "I",
         "asignaturas": [
           {
             "numero": 1,
@@ -21,25 +20,25 @@ export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
           },
           {
             "numero": 3,
-            "nombre": "Física I",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 4,
             "nombre": "Inglés I",
             "para_cursar_aprobar": [],
             "para_cursar_cursar": []
           },
           {
-            "numero": 5,
+            "numero": 4,
             "nombre": "Lógica y Estructuras Discretas",
             "para_cursar_aprobar": [],
             "para_cursar_cursar": []
           },
           {
-            "numero": 6,
+            "numero": 5,
             "nombre": "Algoritmos y Estructuras de Datos",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": []
+          },
+          {
+            "numero": 6,
+            "nombre": "Física I",
             "para_cursar_aprobar": [],
             "para_cursar_cursar": []
           },
@@ -54,30 +53,6 @@ export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
             "nombre": "Sistemas y Procesos de Negocio",
             "para_cursar_aprobar": [],
             "para_cursar_cursar": []
-          },
-          {
-            "numero": 9,
-            "nombre": "Análisis Matemático II",
-            "para_cursar_aprobar": [1, 2],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 10,
-            "nombre": "Física II",
-            "para_cursar_aprobar": [1, 3],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 11,
-            "nombre": "Ingeniería y Sociedad",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 12,
-            "nombre": "Inglés II",
-            "para_cursar_aprobar": [4],
-            "para_cursar_cursar": []
           }
         ]
       },
@@ -85,29 +60,54 @@ export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
         "nivel": "II",
         "asignaturas": [
           {
-            "numero": 13,
+            "numero": 9,
+            "nombre": "Análisis Matemático II",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 2]
+          },
+          {
+            "numero": 10,
             "nombre": "Sintaxis y Semántica de los Lenguajes",
-            "para_cursar_aprobar": [5, 6],
-            "para_cursar_cursar": []
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [4,5]
+          },
+          {
+            "numero": 11,
+            "nombre": "Paradigmas de Programación",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [4, 5]
+          },
+          {
+            "numero": 12,
+            "nombre": "Sistemas Operativos",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [7]
+          },
+          {
+            "numero": 13,
+            "nombre": "Física II",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [1, 6]
           },
           {
             "numero": 14,
-            "nombre": "Paradigmas de Programación",
-            "para_cursar_aprobar": [5, 6],
-            "para_cursar_cursar": []
+            "nombre": "Análisis de Sistemas de Información",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [8]
           },
           {
             "numero": 15,
-            "nombre": "Sistemas Operativos",
-            "para_cursar_aprobar": [7],
-            "para_cursar_cursar": []
+            "nombre": "Inglés II",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [3]
           },
           {
             "numero": 16,
-            "nombre": "Análisis de Sistemas de Información (integradora)",
-            "para_cursar_aprobar": [6, 8],
+            "nombre": "Ingeniería y Sociedad",
+            "para_cursar_aprobar": [],
             "para_cursar_cursar": []
           }
+       
         ]
       },
       {
@@ -115,92 +115,93 @@ export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
         "asignaturas": [
           {
             "numero": 17,
-            "nombre": "Probabilidad y Estadística",
-            "para_cursar_aprobar": [1, 2],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 18,
-            "nombre": "Economía",
-            "para_cursar_aprobar": [1, 2],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 19,
-            "nombre": "Bases de Datos",
-            "para_cursar_aprobar": [13, 16],
-            "para_cursar_cursar": [5, 6]
-          },
-          {
-            "numero": 20,
-            "nombre": "Desarrollo de Software",
-            "para_cursar_aprobar": [],
-            "para_cursar_cursar": [5, 6, 14, 16]
-          },
-          {
-            "numero": 21,
-            "nombre": "Comunicación de Datos",
-            "para_cursar_aprobar": [3, 7],
-            "para_cursar_cursar": []
-          },
-          {
-            "numero": 22,
-            "nombre": "Análisis Numérico",
-            "para_cursar_aprobar": [9],
-            "para_cursar_cursar": [1, 2]
-          },
-          {
-            "numero": 23,
-            "nombre": "Diseño de Sistemas de Información (integradora)",
-            "para_cursar_aprobar": [14, 16],
-            "para_cursar_cursar": [4, 6, 8]
-          },
-          {
-            "numero": 24,
-            "nombre": "Legislación",
-            "para_cursar_aprobar": [11],
-            "para_cursar_cursar": []
-          }
+        "nombre": "Probabilidad y Estadística",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2]
+      },
+      {
+        "numero": 18,
+        "nombre": "Bases de Datos",
+        "para_cursar_aprobar": [4, 5],
+        "para_cursar_cursar": [10, 14]
+      },
+      {
+        "numero": 19,
+        "nombre": "Desarrollo de Software I",
+        "para_cursar_aprobar": [4, 5],
+        "para_cursar_cursar": [11, 14]
+      },
+      {
+        "numero": 20,
+        "nombre": "Comunicación de Datos",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [6 , 7]
+      },
+      {
+        "numero": 21,
+        "nombre": "Análisis Numérico",
+        "para_cursar_aprobar": [1,2],
+        "para_cursar_cursar": [9]
+      },
+      {
+        "numero": 22,
+        "nombre": "Diseño de Sistemas de Información",
+        "para_cursar_aprobar": [3, 5, 8],
+        "para_cursar_cursar": [11, 14]
+      },
+      {
+        "numero": 23,
+        "nombre": "Economía",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2]
+      }
+
         ]
       },
       {
         "nivel": "IV",
         "asignaturas": [
           {
+            "numero": 24,
+            "nombre": "Legislación",
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [16]
+          },
+          {
             "numero": 25,
             "nombre": "Ingeniería y Calidad de Software",
-            "para_cursar_aprobar": [19, 20, 23],
-            "para_cursar_cursar": [13, 14]
+            "para_cursar_aprobar": [10, 11],
+            "para_cursar_cursar": [18, 19, 22]
           },
           {
             "numero": 26,
             "nombre": "Redes de Datos",
-            "para_cursar_aprobar": [15, 21],
-            "para_cursar_cursar": []
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [12, 20]
           },
           {
             "numero": 27,
             "nombre": "Investigación Operativa",
-            "para_cursar_aprobar": [17, 22],
-            "para_cursar_cursar": []
+            "para_cursar_aprobar": [],
+            "para_cursar_cursar": [17, 21]
           },
           {
             "numero": 28,
             "nombre": "Simulación",
-            "para_cursar_aprobar": [17],
-            "para_cursar_cursar": [9]
+            "para_cursar_aprobar": [9],
+            "para_cursar_cursar": [17]
           },
           {
             "numero": 29,
-            "nombre": "Tecnologías para la automatización",
-            "para_cursar_aprobar": [10, 22],
-            "para_cursar_cursar": [9]
+            "nombre": "Tecnologías para la Automatización",
+            "para_cursar_aprobar": [9],
+            "para_cursar_cursar": [13, 21]
           },
           {
             "numero": 30,
-            "nombre": "Administración de Sistemas de Información (integradora)",
-            "para_cursar_aprobar": [16],
-            "para_cursar_cursar": [18, 23]
+            "nombre": "Administración de Sistemas de Información",
+            "para_cursar_aprobar": [14],
+            "para_cursar_cursar": [22, 23]
           }
         ]
       },
@@ -209,40 +210,40 @@ export const plan_ing_en_sistemas_2025: RegimenCorrelatividades = {
         "asignaturas": [
           {
             "numero": 31,
-            "nombre": "Inteligencia Artificial",
-            "para_cursar_aprobar": [17, 22],
-            "para_cursar_cursar": [28]
-          },
-          {
-            "numero": 32,
-            "nombre": "Ciencia de Datos",
-            "para_cursar_aprobar": [17, 19],
-            "para_cursar_cursar": [28]
-          },
-          {
-            "numero": 33,
-            "nombre": "Sistemas de Gestión",
-            "para_cursar_aprobar": [18, 27],
-            "para_cursar_cursar": [23]
-          },
-          {
-            "numero": 34,
-            "nombre": "Gestión Gerencial",
-            "para_cursar_aprobar": [24, 30],
-            "para_cursar_cursar": [18]
-          },
-          {
-            "numero": 35,
-            "nombre": "Seguridad en los Sistemas de Información",
-            "para_cursar_aprobar": [20, 21],
-            "para_cursar_cursar": [26, 30]
-          },
-          {
-            "numero": 36,
-            "nombre": "Proyecto Final (integradora)",
-            "para_cursar_aprobar": [25, 26, 30],
-            "para_cursar_cursar": [12, 20, 23]
-          }
+        "nombre": "Inteligencia Artificial",
+        "para_cursar_aprobar": [17,21],
+        "para_cursar_cursar": [28]
+      },
+      {
+        "numero": 32,
+        "nombre": "Ciencia de Datos",
+        "para_cursar_aprobar": [17,18],
+        "para_cursar_cursar": [28]
+      },
+      {
+        "numero": 33,
+        "nombre": "Sistemas de Gestión",
+        "para_cursar_aprobar": [22],
+        "para_cursar_cursar": [23, 27]
+      },
+      {
+        "numero": 34,
+        "nombre": "Gestión Gerencial",
+        "para_cursar_aprobar": [23],
+        "para_cursar_cursar": [24, 30]
+      },
+      {
+        "numero": 35,
+        "nombre": "Seguridad en los Sistemas de Información",
+        "para_cursar_aprobar": [19, 20],
+        "para_cursar_cursar": [26, 30]
+      },
+      {
+        "numero": 36,
+        "nombre": "Proyecto Final",
+        "para_cursar_aprobar": [15, 19, 22],
+        "para_cursar_cursar": [25, 26, 30]
+      }
         ]
       }
     ],

--- a/docs/2023/IngMecanica.ts
+++ b/docs/2023/IngMecanica.ts
@@ -1,4 +1,4 @@
-import { RegimenCorrelatividades } from "../interfaces/regimen";
+import { RegimenCorrelatividades } from "./interfaces/regimen";
 
 export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
       "carrera": "Ingeniería Mecánica",
@@ -235,7 +235,7 @@ export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
               "numero": 35,
               "nombre": "Máquinas Alternativas y Turbomáquinas",
               "para_cursar_aprobar": [13,17],
-              "para_cursar_cursar": [20,28,30,31,,32]
+              "para_cursar_cursar": [20,28,30,31,32]
             },
             {
               "numero": 36,

--- a/docs/2023/IngMecanica.ts
+++ b/docs/2023/IngMecanica.ts
@@ -1,4 +1,4 @@
-import { RegimenCorrelatividades } from "./interfaces/regimen";
+import { RegimenCorrelatividades } from "../interfaces/regimen";
 
 export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
       "carrera": "Ingeniería Mecánica",
@@ -9,61 +9,49 @@ export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
           "asignaturas": [
             {
               "numero": 1,
-              "nombre": "ANÁLISIS MATEMÁTICO I",
+              "nombre": "Análisis Matemático I",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 2,
-              "nombre": "ÁLGEBRA Y GEOMETRÍA ANALÍTICA",
+              "nombre": "Álgebra y Geometría Analítica",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 3,
-              "nombre": "INGENIERÍA Y SOCIEDAD",
+              "nombre": "Ingeniería y Sociedad",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 4,
-              "nombre": "INGENIERÍA MECÁNICA I",
+              "nombre": "Ingeniería Mecánica I",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 5,
-              "nombre": "SISTEMAS DE REPRESENTACIÓN",
+              "nombre": "Sistemas de Representación",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 6,
-              "nombre": "FÍSICA I",
+              "nombre": "Química General",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 7,
-              "nombre": "QUÍMICA GENERAL",
+              "nombre": "Física I",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             },
             {
               "numero": 8,
-              "nombre": "INGENIERÍA AMBIENTAL Y SEGURIDAD INDUSTRIAL",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [7, 6]
-            },
-            {
-              "numero": 9,
-              "nombre": "FUNDAMENTOS DE INFORMÁTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": []
-            },
-            {
-              "numero": 10,
-              "nombre": "INGLÉS I",
+              "nombre": "Fundamentos de Informática",
               "para_cursar_aprobar": [],
               "para_cursar_cursar": []
             }
@@ -73,111 +61,111 @@ export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
           "nivel": "II",
           "asignaturas": [
             {
-              "numero": 11,
-              "nombre": "ANÁLISIS MATEMÁTICO II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2]
-            },
-            {
-              "numero": 12,
-              "nombre": "ESTABILIDAD I",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2, 6]
-            },
-            {
-              "numero": 13,
-              "nombre": "MATERIALES NO METÁLICOS",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [7, 6]
-            },
-            {
-              "numero": 14,
-              "nombre": "MATERIALES METÁLICOS",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [7, 6]
-            },
-            {
-              "numero": 15,
-              "nombre": "FÍSICA II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 6]
-            },
-            {
-              "numero": 16,
-              "nombre": "INGENIERÍA MECÁNICA II",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [15, 4]
-            },
-            {
-              "numero": 17,
-              "nombre": "PROBABILIDAD Y ESTADÍSTICA",
-              "para_cursar_aprobar": [],
-              "para_cursar_cursar": [1, 2]
-            },
-            {
-              "numero": 18,
-              "nombre": "INGLÉS II",
-              "para_cursar_aprobar": [10],
-              "para_cursar_cursar": []
-            }
+             "numero": 9,
+        "nombre": "Análisis Matemático II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1,2]
+      },
+      {
+        "numero": 10,
+        "nombre": "Estabilidad I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 2]
+      },
+      {
+        "numero": 11,
+        "nombre": "Materiales No Metálicos",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [6,7]
+      },
+      {
+        "numero": 12,
+        "nombre": "Materiales Metálicos",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [6,7]
+      },
+      {
+        "numero": 13,
+        "nombre": "Física II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [1, 7]
+      },
+      {
+        "numero": 14,
+        "nombre": "Ingeniería Ambiental y Seguridad Industrial",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [6,7]
+      },
+      {
+        "numero": 15,
+        "nombre": "Ingeniería Mecánica II",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": [4,7]
+      },
+      {
+        "numero": 16,
+        "nombre": "Inglés I",
+        "para_cursar_aprobar": [],
+        "para_cursar_cursar": []
+      }
           ]
         },
         {
           "nivel": "III",
           "asignaturas": [
             {
+              "numero": 17,
+              "nombre": "Termodinámica",
+              "para_cursar_aprobar": [1,2,7],
+              "para_cursar_cursar": [9,13]
+            },
+            {
+              "numero": 18,
+              "nombre": "Mecánica Racional I",
+              "para_cursar_aprobar": [1,2,7],
+              "para_cursar_cursar": [9,10]
+            },
+            {
               "numero": 19,
-              "nombre": "TERMODINÁMICA",
-              "para_cursar_aprobar": [1, 2, 6],
-              "para_cursar_cursar": [11, 15]
+              "nombre": "Estabilidad II",
+              "para_cursar_aprobar": [1,2,7],
+              "para_cursar_cursar": [9, 10]
             },
             {
               "numero": 20,
-              "nombre": "MECÁNICA RACIONAL",
-              "para_cursar_aprobar": [1, 2, 6],
-              "para_cursar_cursar": [12, 11]
+              "nombre": "Mediciones y Ensayos",
+              "para_cursar_aprobar": [1,7],
+              "para_cursar_cursar": [10,12,13]
             },
             {
               "numero": 21,
-              "nombre": "ESTABILIDAD II",
-              "para_cursar_aprobar": [1, 2, 6],
-              "para_cursar_cursar": [12, 11]
+              "nombre": "Diseño Mecánico",
+              "para_cursar_aprobar": [7,4,5,8],
+              "para_cursar_cursar": [11,10,12]
             },
             {
               "numero": 22,
-              "nombre": "MEDICIONES Y ENSAYOS",
-              "para_cursar_aprobar": [1, 6],
-              "para_cursar_cursar": [12, 14, 15]
+              "nombre": "Ingeniería Mecánica III",
+              "para_cursar_aprobar": [1,6,7,4],
+              "para_cursar_cursar": [11,12,15]
             },
             {
               "numero": 23,
-              "nombre": "DISEÑO MECÁNICO",
-              "para_cursar_aprobar": [6, 4, 5, 9],
-              "para_cursar_cursar": [13, 12, 14]
+              "nombre": "Cálculo Avanzado",
+              "para_cursar_aprobar": [1,2,8],
+              "para_cursar_cursar": [9]
             },
             {
               "numero": 24,
-              "nombre": "INGENIERÍA MECÁNICA III",
-              "para_cursar_aprobar": [1, 7, 6, 4],
-              "para_cursar_cursar": [13, 14, 16]
+              "nombre": "Probabilidad y Estadística",
+              "para_cursar_aprobar": [],
+              "para_cursar_cursar": [1,2]
             },
             {
               "numero": 25,
-              "nombre": "CÁLCULO AVANZADO",
-              "para_cursar_aprobar": [1, 2],
-              "para_cursar_cursar": [11, 9]
-            },
-            {
-              "numero": 26,
-              "nombre": "ELECTROTECNIA Y MÁQUINAS ELÉCTRICAS",
-              "para_cursar_aprobar": [1, 2, 6],
-              "para_cursar_cursar": [11, 15]
-            },
-            {
-              "numero": 27,
-              "nombre": "PROCESOS DE MANUFACTURA",
-              "para_cursar_aprobar": [1, 7, 6, 4],
-              "para_cursar_cursar": [13, 14, 16]
+              "nombre": "Inglés II",
+              "para_cursar_aprobar": [16],
+              "para_cursar_cursar": []
             }
           ]
         },
@@ -185,52 +173,52 @@ export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
           "nivel": "IV",
           "asignaturas": [
             {
-              "numero": 28,
-              "nombre": "ECONOMÍA",
+              "numero": 26,
+              "nombre": "Economía",
               "para_cursar_aprobar": [3],
-              "para_cursar_cursar": [16]
+              "para_cursar_cursar": [15]
+            },
+            {
+              "numero": 27,
+              "nombre": "Elementos de Máquinas",
+              "para_cursar_aprobar": [6,9,10],
+              "para_cursar_cursar": [11,12,18,19,22]
+            },
+            {
+              "numero": 28,
+              "nombre": "Tecnología del Calor",
+              "para_cursar_aprobar": [9,13],
+              "para_cursar_cursar": [17]
             },
             {
               "numero": 29,
-              "nombre": "ELEMENTOS DE MÁQUINAS",
-              "para_cursar_aprobar": [7, 12, 11],
-              "para_cursar_cursar": [13, 14, 20, 21, 24]
+              "nombre": "Metrología e Ingeniería de la Calidad",
+              "para_cursar_aprobar": [2,12,13],
+              "para_cursar_cursar": [20,24]
             },
             {
               "numero": 30,
-              "nombre": "TECNOLOGÍA DEL CALOR",
-              "para_cursar_aprobar": [11, 15],
-              "para_cursar_cursar": [19]
+              "nombre": "Mecánica de los Fluidos",
+              "para_cursar_aprobar": [9,13],
+              "para_cursar_cursar": [17]
             },
             {
               "numero": 31,
-              "nombre": "METROLOGÍA E INGENIERÍA DE CALIDAD",
-              "para_cursar_aprobar": [2, 14, 15],
-              "para_cursar_cursar": [22, 17]
+              "nombre": "Electrotecnia y Máquinas Eléctricas",
+              "para_cursar_aprobar": [9,13],
+              "para_cursar_cursar": [1,2,7]
             },
             {
               "numero": 32,
-              "nombre": "MECÁNICA DE LOS FLUIDOS",
-              "para_cursar_aprobar": [11, 15],
-              "para_cursar_cursar": [19]
+              "nombre": "Electrónica y Sistemas de Control",
+              "para_cursar_aprobar": [1,2,7],
+              "para_cursar_cursar": [9,13,23]
             },
             {
               "numero": 33,
-              "nombre": "ELECTRÓNICA Y SISTEMAS DE CONTROL",
-              "para_cursar_aprobar": [1, 2, 6],
-              "para_cursar_cursar": [11, 15, 25]
-            },
-            {
-              "numero": 34,
-              "nombre": "ESTABILIDAD III",
-              "para_cursar_aprobar": [1, 2, 6, 12],
-              "para_cursar_cursar": [21]
-            },
-            {
-              "numero": 35,
-              "nombre": "LEGISLACIÓN",
-              "para_cursar_aprobar": [3],
-              "para_cursar_cursar": [16]
+              "nombre": "Estabilidad III",
+              "para_cursar_aprobar": [1,2,7,10],
+              "para_cursar_cursar": [19]
             }
           ]
         },
@@ -238,40 +226,46 @@ export const plan_ing_mecanica_2023: RegimenCorrelatividades = {
           "nivel": "V",
           "asignaturas": [
             {
+              "numero": 34,
+              "nombre": "Tecnología de la Fabricación",
+              "para_cursar_aprobar": [11,10,12,21],
+              "para_cursar_cursar": [27,29]
+            },
+            {
+              "numero": 35,
+              "nombre": "Máquinas Alternativas y Turbomáquinas",
+              "para_cursar_aprobar": [13,17],
+              "para_cursar_cursar": [20,28,30,31,,32]
+            },
+            {
               "numero": 36,
-              "nombre": "TECNOLOGÍA DE LA FABRICACIÓN",
-              "para_cursar_aprobar": [13, 12, 14, 23],
-              "para_cursar_cursar": [29, 31]
+              "nombre": "Instalaciones Industriales",
+              "para_cursar_aprobar": [10,14,17],
+              "para_cursar_cursar": [20,38,30,31,32]
             },
             {
               "numero": 37,
-              "nombre": "MÁQUINAS ALTERNATIVAS Y TURBOMÁQUINAS",
-              "para_cursar_aprobar": [15, 19],
-              "para_cursar_cursar": [30]
+              "nombre": "Organización Industrial",
+              "para_cursar_aprobar": [22],
+              "para_cursar_cursar": [26]
             },
             {
               "numero": 38,
-              "nombre": "INSTALACIONES INDUSTRIALES",
-              "para_cursar_aprobar": [12, 8],
-              "para_cursar_cursar": [22, 30, 32, 26, 33, 19]
+              "nombre": "Legislación",
+              "para_cursar_aprobar": [3],
+              "para_cursar_cursar": [22]
             },
             {
               "numero": 39,
-              "nombre": "ORGANIZACIÓN INDUSTRIAL",
-              "para_cursar_aprobar": [16],
-              "para_cursar_cursar": [28]
+              "nombre": "Mantenimiento",
+              "para_cursar_aprobar": [12,13,18,19],
+              "para_cursar_cursar": [20,26,27]
             },
             {
               "numero": 40,
-              "nombre": "MANTENIMIENTO",
-              "para_cursar_aprobar": [14, 15, 20, 12],
-              "para_cursar_cursar": [22, 28, 29]
-            },
-            {
-              "numero": 41,
-              "nombre": "PROYECTO FINAL",
-              "para_cursar_aprobar": [20, 21, 22, 23],
-              "para_cursar_cursar": [29, 31, 26, 33]
+              "nombre": "Proyecto Final",
+              "para_cursar_aprobar": [18,19,20,21],
+              "para_cursar_cursar": [27,29,31,32]
             }
           ]
         }


### PR DESCRIPTION
This pull request includes updates to the academic plans for Ingeniería Civil, Ingeniería Eléctrica, and Ingeniería Electrónica. The changes focus on fixing import paths, standardizing subject names, updating course prerequisites and corequisites, and adjusting the structure of the academic plans.

### General Fixes:
* Fixed import paths for `RegimenCorrelatividades` in `docs/2023/IngCivil.ts`, `docs/2023/IngElectrica.ts`, and `docs/2023/IngElectronica.ts` to use the correct relative path (`../interfaces/regimen`). [[1]](diffhunk://#diff-05665582a8fbb11926e7c143b7064b354f355dcbe7e0e76de1b35a9687bbfb43L1-R1) [[2]](diffhunk://#diff-c5046ec13fe8e6c23a7f41860c667436c2f970976e4d452ea287854bf0567594L1-R288) [[3]](diffhunk://#diff-a5b95b62a2a117e6dddbf967791a2ff9cc90d1b6b67d33c255f5e99654727d1fL1-R1)

### Standardization of Subject Names:
* Standardized subject names across all academic plans by capitalizing only the first letter of each word and updating some subject names to more accurate translations (e.g., "ANÁLISIS MATEMÁTICO I" to "Análisis Matemático I"). [[1]](diffhunk://#diff-05665582a8fbb11926e7c143b7064b354f355dcbe7e0e76de1b35a9687bbfb43L12-R54) [[2]](diffhunk://#diff-c5046ec13fe8e6c23a7f41860c667436c2f970976e4d452ea287854bf0567594L1-R288)

### Updates to Ingeniería Civil Plan:
* Adjusted course prerequisites (`para_cursar_aprobar`) and corequisites (`para_cursar_cursar`) for several subjects in the `plan_ing_civil_2023` academic plan to better reflect the curriculum structure. [[1]](diffhunk://#diff-05665582a8fbb11926e7c143b7064b354f355dcbe7e0e76de1b35a9687bbfb43L70-R103) [[2]](diffhunk://#diff-05665582a8fbb11926e7c143b7064b354f355dcbe7e0e76de1b35a9687bbfb43L112-R168) [[3]](diffhunk://#diff-05665582a8fbb11926e7c143b7064b354f355dcbe7e0e76de1b35a9687bbfb43L177-R215) [[4]](diffhunk://#diff-05665582a8fbb11926e7c143b7064b354f355dcbe7e0e76de1b35a9687bbfb43L224-R273)

### Updates to Ingeniería Eléctrica Plan:
* Corrected the academic plan year from "2025a" to "2023" and reorganized the structure of the `plan_ing_electrica_2025` plan, including updates to prerequisites and corequisites for multiple courses.

### Updates to Ingeniería Electrónica Plan:
* Fixed the import path for `RegimenCorrelatividades` and ensured consistency in the structure of the academic plan for `plan_ing_electronica_2023`.