### PR TITLE
FEAT - Disable change career in Profile

### DIFF
--- a/app/dashboard/profile/_components/ProfileHeader.tsx
+++ b/app/dashboard/profile/_components/ProfileHeader.tsx
@@ -23,9 +23,10 @@ interface ProfileHeaderProps {
   profile: Profile | null
   careers: Career[]
   onCareerChangeClick: () => void
+  isCareerChangeDisabled?: boolean
 }
 
-export function ProfileHeader({ user, profile, careers, onCareerChangeClick }: ProfileHeaderProps) {
+export function ProfileHeader({ user, profile, careers, onCareerChangeClick, isCareerChangeDisabled }: ProfileHeaderProps) {
   const selectedCareerName = careers.find((c) => c.id === profile?.career_id)?.name || "No asignada"
 
   const getUserInitials = () => {
@@ -72,11 +73,11 @@ export function ProfileHeader({ user, profile, careers, onCareerChangeClick }: P
           
           <Button 
             onClick={onCareerChangeClick} 
-            disabled={!user} 
-            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white border-0 transition-all duration-300"
+            disabled={!user || isCareerChangeDisabled} 
+            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white border-0 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Settings className="h-4 w-4 mr-2" />
-            Cambiar Carrera
+            {isCareerChangeDisabled ? "Carrera Seleccionada" : "Cambiar Carrera"}
           </Button>
         </div>
       </CardContent>

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -90,6 +90,7 @@ export default function ProfilePage() {
               profile={profile}
               careers={careers}
               onCareerChangeClick={() => setIsModalOpen(true)}
+              isCareerChangeDisabled={true}
             />
           </motion.div>
 


### PR DESCRIPTION
This pull request introduces significant updates to the `MateriasPage` and related components to enhance functionality, improve user experience, and simplify code structure. Key changes include the addition of level-based filtering for subjects, new modals for level and career selection, and updates to the `ProfileHeader` to support a disabled state for career changes.

### Enhancements to `MateriasPage`:

* **Level-based filtering for subjects**: Introduced a `selectedLevel` state to filter subjects by level. Added logic to display a message when no subjects match the selected level. (`[[1]](diffhunk://#diff-bc1c4833dd75b3b461e53d88ef7ec1c3428688a742a89996741b4ffec8766eb9L33-R75)`, `[[2]](diffhunk://#diff-bc1c4833dd75b3b461e53d88ef7ec1c3428688a742a89996741b4ffec8766eb9L166-L250)`)
* **New header with buttons**: Added a new header with buttons for "Cambiar Carrera" (disabled with a toast notification) and "Seleccionar Nivel" (opens the level selection modal). (`[app/dashboard/materias/page.tsxR145-R164](diffhunk://#diff-bc1c4833dd75b3b461e53d88ef7ec1c3428688a742a89996741b4ffec8766eb9R145-R164)`)
* **Refactored subject rendering**: Replaced career-based grouping and rendering with a grid layout for filtered subjects using the new `SubjectCard` component. (`[app/dashboard/materias/page.tsxL166-L250](diffhunk://#diff-bc1c4833dd75b3b461e53d88ef7ec1c3428688a742a89996741b4ffec8766eb9L166-L250)`)

### New Modals:

* **Level selection modal**: Added a `LevelSelectionModal` to allow users to select a level, updating the `selectedLevel` state. (`[app/dashboard/materias/page.tsxR280-R292](diffhunk://#diff-bc1c4833dd75b3b461e53d88ef7ec1c3428688a742a89996741b4ffec8766eb9R280-R292)`)
* **Career selection modal**: Integrated a `CareerSelectionModal` placeholder for future career selection functionality. (`[app/dashboard/materias/page.tsxR280-R292](diffhunk://#diff-bc1c4833dd75b3b461e53d88ef7ec1c3428688a742a89996741b4ffec8766eb9R280-R292)`)

### Updates to `ProfileHeader`:

* **Career change button enhancements**: Updated the `ProfileHeader` to include an optional `isCareerChangeDisabled` prop. The button now displays a disabled state with adjusted styles and text when career changes are not allowed. (`[[1]](diffhunk://#diff-ff2542e8ae260597c0e26ced0e37035e0a11091e743d3b40ac3dba015590457aR26-R29)`, `[[2]](diffhunk://#diff-ff2542e8ae260597c0e26ced0e37035e0a11091e743d3b40ac3dba015590457aL75-R80)`)
* **Disabled career change on profile page**: Set `isCareerChangeDisabled` to `true` in the `ProfilePage` to reflect the disabled state for career changes. (`[app/dashboard/profile/page.tsxR93](diffhunk://#diff-a7eebc08286396855ebfcf48e7db26f6378fd4b71d3627dfd8e941ee7caf6c08R93)`)