### PR TITLE
FEAT  - Disable Profile

### DIFF
--- a/app/dashboard/profile/_components/ProfileHeader.tsx
+++ b/app/dashboard/profile/_components/ProfileHeader.tsx
@@ -72,7 +72,7 @@ export function ProfileHeader({ user, profile, careers, onCareerChangeClick }: P
           
           <Button 
             onClick={onCareerChangeClick} 
-            disabled={!user} 
+            disabled={true} 
             className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white border-0 transition-all duration-300"
           >
             <Settings className="h-4 w-4 mr-2" />


### PR DESCRIPTION
This pull request includes a minor change to the `ProfileHeader` component in the `app/dashboard/profile/_components/ProfileHeader.tsx` file. The change ensures that the "Career Change" button is always disabled by setting the `disabled` property to `true`.

* [`app/dashboard/profile/_components/ProfileHeader.tsx`](diffhunk://#diff-ff2542e8ae260597c0e26ced0e37035e0a11091e743d3b40ac3dba015590457aL75-R75): Updated the `disabled` property of the "Career Change" button to always be `true`, replacing the previous condition that depended on the `user` prop.